### PR TITLE
refactor: Fix css and meta information

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-    "name": "typescript-react-redux-boilerplate",
+    "name": "lavinia",
     "version": "1.0.0",
     "private": true,
-    "description": "A frontend boilerplate with React, Redux and Typescript",
+    "description": "A seat distribution application for modern democracies",
     "main": "index.js",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/app/Layout/ComputationSettings/SettingMenuComponent.css
+++ b/src/app/Layout/ComputationSettings/SettingMenuComponent.css
@@ -1,0 +1,51 @@
+.menu {
+    background-color: #f5f5f5;
+    padding: 15px;
+    display: flex;
+    flex-direction: column;
+}
+
+.menu h1 {
+    margin-top: 0.5em;
+    margin-bottom: 1em;
+    font-size: 2em;
+    border-bottom: 2px solid #ff6e00;
+}
+
+.menu h2 {
+    margin-bottom: 0.5em;
+    font-size: 1.3em;
+    border-bottom: 1px dashed #ff6e00;
+}
+
+.menu label {
+    font-weight: normal;
+    text-align: right;
+    line-height: 34px;
+}
+
+.menu select:focus,
+.menu input:focus {
+    border-color: #ff6e00;
+}
+
+.menu button {
+    margin-right: 1em;
+    background-color: #ff6e00;
+    border: 1px solid #ff6e00;
+    border-radius: 4px;
+    color: #fff;
+    height: 34px;
+
+    /* For animation of styling */
+    -webkit-transition-duration: 0.4s; /* Safari */
+    transition-duration: 0.4s;
+}
+
+.menu button:hover,
+.menu button:active,
+.menu button:focus {
+    background-color: #fff;
+    color: #000;
+    outline: none;
+}

--- a/src/app/Layout/ComputationSettings/SettingMenuComponent.tsx
+++ b/src/app/Layout/ComputationSettings/SettingMenuComponent.tsx
@@ -5,6 +5,7 @@ import { Button } from "../Button";
 import { Election, ElectionType } from "../Interfaces/Models";
 import { SmartNumericInput } from "../SmartNumericInput";
 import { AlgorithmType } from "../Types/AlgorithmType";
+import * as style from "./SettingMenuComponent.css";
 
 export interface SettingMenuProps {
     electionType: ElectionType;
@@ -122,7 +123,7 @@ export class SettingMenuComponent extends React.Component<SettingMenuProps, {}> 
 
     render() {
         return (
-            <div className="settings-menu">
+            <div className={style.menu}>
                 <h1 className="h2">Stortingsvalg</h1>
                 <form>
                     <div className="form-group row">

--- a/src/app/Layout/NavigationMenu/NavMenu.css
+++ b/src/app/Layout/NavigationMenu/NavMenu.css
@@ -1,0 +1,64 @@
+.nav li .glyphicon {
+    margin-right: 10px;
+}
+
+/* Highlighting rules for nav menu items */
+.nav li a.active,
+.nav li a.active:hover,
+.nav li a.active:focus {
+    background-color: #4189c7;
+    color: white;
+}
+
+.container {
+    height: 5em;
+    margin-bottom: 20px;
+    width: 100%;
+    padding: 0;
+    text-transform: uppercase;
+    background-color: #fff;
+    border-bottom: 3px solid #e9e6e2;
+}
+
+.container li a:active,
+.container li a:hover,
+.container li a:focus {
+    color: #ff6e00;
+    border: none;
+    outline: none;
+}
+.container ul {
+    padding: 0;
+    align-items: center;
+    display: flex;
+    list-style: none;
+}
+
+.container li {
+    margin-top: 10px;
+    padding-right: 1.5em;
+}
+
+.container li:last-child {
+    padding-right: 2em;
+}
+
+.container a {
+    color: black;
+}
+
+.customHeader {
+    padding: 0;
+    margin: auto;
+    text-transform: capitalize;
+    font-variant: small-caps;
+    font-size: 2.5em;
+}
+
+.customHeader a,
+.customHeader a:hover,
+.customHeader a:active,
+.customHeader a:active {
+    text-decoration: none;
+    color: #a39161 !important;
+}

--- a/src/app/Layout/NavigationMenu/NavMenu.css
+++ b/src/app/Layout/NavigationMenu/NavMenu.css
@@ -57,8 +57,7 @@
 
 .customHeader a,
 .customHeader a:hover,
-.customHeader a:active,
 .customHeader a:active {
     text-decoration: none;
-    color: #a39161 !important;
+    color: #a39161;
 }

--- a/src/app/Layout/NavigationMenu/NavMenu.tsx
+++ b/src/app/Layout/NavigationMenu/NavMenu.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
+import * as style from "./NavMenu.css";
 
 export class NavMenu extends React.Component<{}, {}> {
     public render() {
         return (
-            <div className="nav_container">
+            <div className={style.container}>
                 <ul>
-                    <li className="laviniaLogo">
+                    <li className={style.customHeader}>
                         <a href="">Lavinia</a>
                     </li>
                     <li>

--- a/src/app/Layout/NavigationMenu/NavMenu.tsx
+++ b/src/app/Layout/NavigationMenu/NavMenu.tsx
@@ -10,7 +10,7 @@ export class NavMenu extends React.Component<{}, {}> {
                         <a href="">Lavinia</a>
                     </li>
                     <li>
-                        <a target="_blank" href="/swagger">
+                        <a target="_blank" href="https://mandater-testing.azurewebsites.net/swagger">
                             API
                         </a>
                     </li>

--- a/src/app/Layout/PresentationSettings/PresentationMenu.css
+++ b/src/app/Layout/PresentationSettings/PresentationMenu.css
@@ -1,0 +1,51 @@
+.menu {
+    background-color: #f5f5f5;
+    padding: 15px;
+    display: flex;
+    flex-direction: column;
+}
+
+.menu h1 {
+    margin-top: 0.5em;
+    margin-bottom: 1em;
+    font-size: 2em;
+    border-bottom: 2px solid #ff6e00;
+}
+
+.menu h2 {
+    margin-bottom: 0.5em;
+    font-size: 1.3em;
+    border-bottom: 1px dashed #ff6e00;
+}
+
+.menu label {
+    font-weight: normal;
+    text-align: right;
+    line-height: 34px;
+}
+
+.menu select:focus,
+.menu input:focus {
+    border-color: #ff6e00;
+}
+
+.menu button {
+    margin-right: 1em;
+    background-color: #ff6e00;
+    border: 1px solid #ff6e00;
+    border-radius: 4px;
+    color: #fff;
+    height: 34px;
+
+    /* For animation of styling */
+    -webkit-transition-duration: 0.4s; /* Safari */
+    transition-duration: 0.4s;
+}
+
+.menu button:hover,
+.menu button:active,
+.menu button:focus {
+    background-color: #fff;
+    color: #000;
+    outline: none;
+}

--- a/src/app/Layout/PresentationSettings/PresentationMenu.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationMenu.tsx
@@ -4,7 +4,6 @@ import { default as PresentationSettings } from "./PresentationSettingsContainer
 
 export class PresentationMenu extends React.Component<{}, {}> {
     public render() {
-        // settings-menu contains the styling
         return (
             <div className="presentation-settings-container settings-menu">
                 <PresentationSelection />

--- a/src/app/Layout/PresentationSettings/PresentationMenu.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationMenu.tsx
@@ -1,11 +1,12 @@
 ﻿import * as React from "react";
 import { PresentationSelection } from "./PresentationSelection";
 import { default as PresentationSettings } from "./PresentationSettingsContainer";
+import * as style from "./PresentationMenu.css";
 
 export class PresentationMenu extends React.Component<{}, {}> {
     public render() {
         return (
-            <div className="presentation-settings-container settings-menu">
+            <div className={style.menu}>
                 <PresentationSelection />
                 <PresentationSettings />
             </div>

--- a/src/app/Layout/PresentationSettings/PresentationSelection.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationSelection.tsx
@@ -16,7 +16,7 @@ export class PresentationSelection extends React.Component {
 
     render() {
         return (
-            <div className="presentation-selection">
+            <React.Fragment>
                 <h2>Presentasjonstyper</h2>
                 <PresentationSelectionButton
                     className="btn-block"
@@ -38,7 +38,7 @@ export class PresentationSelection extends React.Component {
                     title={"Mandater per parti"}
                     presentationSelected={PresentationType.SeatsPerParty}
                 />
-            </div>
+            </React.Fragment>
         );
     }
 }

--- a/src/app/Layout/PresentationSettings/PresentationSelection.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationSelection.tsx
@@ -30,7 +30,7 @@ export class PresentationSelection extends React.Component {
                 />
                 <PresentationSelectionButton
                     className="btn-block"
-                    title={"Mandat distribusjon"}
+                    title={"Mandatdistribusjon"}
                     presentationSelected={PresentationType.SeatDistribution}
                 />
                 <PresentationSelectionButton

--- a/src/app/Layout/PresentationSettings/PresentationSettings.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationSettings.tsx
@@ -33,7 +33,7 @@ export class PresentationSettings extends React.Component<PresentationSettingsPr
 
     render() {
         return (
-            <div className="presentation-settings">
+            <React.Fragment>
                 <h2>Presentasjonsinnstillinger</h2>
                 <form>
                     <div className="form-group row">
@@ -59,7 +59,7 @@ export class PresentationSettings extends React.Component<PresentationSettingsPr
                         onChange={this.props.changeDecimals}
                     />
                 </form>
-            </div>
+            </React.Fragment>
         );
     }
 }

--- a/src/app/Layout/PresentationSettings/PresentationSettings.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationSettings.tsx
@@ -36,15 +36,19 @@ export class PresentationSettings extends React.Component<PresentationSettingsPr
             <React.Fragment>
                 <h2>Presentasjonsinnstillinger</h2>
                 <form>
-                    <div className="form-group row">
-                        <input
-                            className="form-check-input"
-                            type="checkbox"
-                            name="no-seats-setting"
-                            checked={this.props.showPartiesWithoutSeats}
-                            onChange={this.props.toggleShowPartiesWithoutSeats}
-                        />
-                        <label htmlFor="no-seats-setting">Vis partier uten mandater</label>
+                    <div className="form-group mb-3">
+                        <div className="form-check form-check-inline">
+                            <input
+                                className="form-check-input"
+                                type="checkbox"
+                                name="no-seats-setting"
+                                checked={this.props.showPartiesWithoutSeats}
+                                onChange={this.props.toggleShowPartiesWithoutSeats}
+                            />
+                            <label className="form-check-label" htmlFor="no-seats-setting">
+                                Vis partier uten mandater
+                            </label>
+                        </div>
                     </div>
                     <SmartNumericInput
                         hidden={!this.needsDecimals()}

--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="https://unpkg.com/react-table@latest/react-table.css">

--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -2,6 +2,10 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://unpkg.com/react-table@latest/react-table.css">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
     <title>Lavinia</title>
   </head>
   <body>

--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Frontend Boilerplate with React and TypeScript</title>
+    <title>Lavinia</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/main.css
+++ b/src/main.css
@@ -3,3 +3,10 @@ body,
 html {
     font-family: "Open Sans", sans-serif;
 }
+
+@media (max-width: 767px) {
+    /* On small screens, the nav menu spans the full width of the screen. Leave a space for it. */
+    body {
+        padding-top: 50px;
+    }
+}

--- a/src/main.css
+++ b/src/main.css
@@ -1,0 +1,5 @@
+/* This is exclusively for non-classes. Whatever applies to everything goes here. */
+body,
+html {
+    font-family: "Open Sans", sans-serif;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { ConnectedRouter } from "react-router-redux";
 import { createBrowserHistory } from "history";
 import { configureStore } from "./app/store";
 import { App } from "./app";
+import "./main.css";
 
 // prepare store
 const history = createBrowserHistory();


### PR DESCRIPTION
# Description
CSS was broken after splitting the client out into its own repository. Some changes make it difficult to entirely replicate the old CSS (particularly that we use an updated version of Bootstrap, and that we now use style imports directly in components as opposed to using strings).

A few minor fixes here and there in addition, like updating the application description and the html title tags.

# Testing
## Setup
1. yarn start
## Expected
A website with (very) similar appearance to the [old application](https://mandater-testing.azurewebsites.net), CSS behaving in an acceptably similar or equivalent way.