### PR TITLE
feat: Re-add state persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "devDependencies": {
         "@types/classnames": "2.2.4",
         "@types/history": "4.6.2",
+        "@types/lodash": "^4.14.113",
         "@types/node": "10.3.2",
         "@types/react": "16.3.17",
         "@types/react-dom": "16.0.6",
@@ -61,6 +62,7 @@
         "bootstrap": "^4.1.1",
         "classnames": "^2.2.6",
         "history": "^4.7.2",
+        "lodash": "^4.17.10",
         "react": "^16.4.0",
         "react-dom": "^16.4.0",
         "react-redux": "^5.0.7",

--- a/src/app/store/index.ts
+++ b/src/app/store/index.ts
@@ -24,3 +24,5 @@ export function configureStore(history: History, initialState?: RootState): Stor
 
     return store;
 }
+
+export * from "./local-storage";

--- a/src/app/store/local-storage.ts
+++ b/src/app/store/local-storage.ts
@@ -1,0 +1,23 @@
+import { RootState } from "../reducers";
+
+export const loadState = () => {
+    try {
+        const serializedState = localStorage.getItem("state");
+        if (serializedState === null) {
+            return undefined;
+        }
+        return JSON.parse(serializedState);
+    } catch (err) {
+        return undefined;
+    }
+};
+
+export const saveState = (state: RootState) => {
+    try {
+        const serializedState = JSON.stringify(state);
+        localStorage.setItem("state", serializedState);
+        console.log(`State saved`);
+    } catch (err) {
+        console.error(err);
+    }
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,23 @@ import * as ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 import { ConnectedRouter } from "react-router-redux";
 import { createBrowserHistory } from "history";
-import { configureStore } from "./app/store";
+import { configureStore, loadState, saveState } from "./app/store";
 import { App } from "./app";
+import { throttle } from "lodash";
+
+const persistedState = loadState();
 
 const history = createBrowserHistory();
-const store = configureStore(history);
+const store = configureStore(history, persistedState);
+
+store.subscribe(
+    throttle(() => {
+        const currentState = store.getState();
+        if (currentState.requestedDataState.enableAutoSave) {
+            saveState(currentState);
+        }
+    }, 3000)
+);
 
 ReactDOM.render(
     <Provider store={store}>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,6 @@ import { createBrowserHistory } from "history";
 import { configureStore } from "./app/store";
 import { App } from "./app";
 
-// prepare store
 const history = createBrowserHistory();
 const store = configureStore(history);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,6 +14,10 @@
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.6.2.tgz#12cfaba693ba20f114ed5765467ff25fdf67ddb0"
 
+"@types/lodash@^4.14.113":
+  version "4.14.113"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.113.tgz#1d1cb063f17fec4cc46f1a90d978ebf441113061"
+
 "@types/node@*":
   version "10.5.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.2.tgz#f19f05314d5421fe37e74153254201a7bf00a707"


### PR DESCRIPTION
# Description
Local storage state persistence was lost in the transition to a more loosely coupled setup. It has been re-added.
# Testing
## Setup
Run yarn so lodash gets set up correctly.
## Expected
State should be loaded from local storage on application load. Every three seconds, the application saves state to local storage.