### PR TITLE
feat: Single district view

### DIFF
--- a/src/app/Layout/ComputationSettings/SettingMenuContainer.tsx
+++ b/src/app/Layout/ComputationSettings/SettingMenuContainer.tsx
@@ -2,7 +2,7 @@
 import { connect } from "react-redux";
 import { SettingMenuComponent } from "./SettingMenuComponent";
 import { updateElectionData } from "../Computation";
-import { updateSettings, toggleAutoCompute } from "../ComputationSettings";
+import { updateSettings, toggleAutoCompute } from ".";
 import { ComputationPayload, SettingsPayload } from "../Interfaces/Payloads";
 import { Election } from "../Interfaces/Models";
 import { getAlgorithmType } from "../Logic/AlgorithmUtils";

--- a/src/app/Layout/Presentation/PresentationComponent.tsx
+++ b/src/app/Layout/Presentation/PresentationComponent.tsx
@@ -1,7 +1,7 @@
 ﻿import * as React from "react";
 import { PresentationType } from "../Types/PresentationType";
 import { LagueDhontResult, PartyResult, DistrictResult } from "../Interfaces/Results";
-import { ElectionOverview, DistrictOverview, SeatsPerParty, SeatDistribution } from "./Views";
+import { ElectionOverview, DistrictOverview, SeatsPerParty, SeatDistribution, SingleCounty } from "./Views";
 import {
     getDistrictTableData,
     getPartyTableData,
@@ -11,6 +11,7 @@ import {
 
 export interface PresentationProps {
     currentPresentation: PresentationType;
+    districtSelected: string;
     decimals: number;
     showPartiesWithoutSeats: boolean;
     results: LagueDhontResult;
@@ -51,6 +52,13 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
                 return <SeatDistribution districtResults={this.getSeatDistributionData()} />;
             case PresentationType.SeatsPerParty:
                 return <SeatsPerParty partyResults={this.getSeatsPerPartyData()} />;
+            case PresentationType.SingleCountyTable:
+                return (
+                    <SingleCounty
+                        districtSelected={this.props.districtSelected}
+                        districtResults={this.getSeatDistributionData()}
+                    />
+                );
             default:
                 console.log(`Could not find presentation type ${this.props.currentPresentation}`);
                 return <g />;

--- a/src/app/Layout/Presentation/PresentationComponent.tsx
+++ b/src/app/Layout/Presentation/PresentationComponent.tsx
@@ -1,7 +1,7 @@
 ﻿import * as React from "react";
 import { PresentationType } from "../Types/PresentationType";
 import { LagueDhontResult, PartyResult, DistrictResult } from "../Interfaces/Results";
-import { ElectionOverview, DistrictOverview, SeatsPerParty, SeatDistribution, SingleCounty } from "./Views";
+import { ElectionOverview, DistrictOverview, SeatsPerParty, SeatDistribution, SingleDistrict } from "./Views";
 import {
     getDistrictTableData,
     getPartyTableData,
@@ -67,7 +67,7 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
                 return <SeatsPerParty partyResults={this.getSeatsPerPartyData()} />;
             case PresentationType.SingleCountyTable:
                 return (
-                    <SingleCounty
+                    <SingleDistrict
                         districtSelected={this.props.districtSelected}
                         districtResults={this.getSingleDistrictData()}
                     />

--- a/src/app/Layout/Presentation/PresentationComponent.tsx
+++ b/src/app/Layout/Presentation/PresentationComponent.tsx
@@ -6,7 +6,8 @@ import {
     getDistrictTableData,
     getPartyTableData,
     getSeatDistributionData,
-    getSeatsPerPartyData
+    getSeatsPerPartyData,
+    roundPartyResults
 } from "./Utilities/PresentationUtilities";
 
 export interface PresentationProps {
@@ -42,6 +43,18 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
         return getSeatsPerPartyData(this.props.results.partyResults, this.props.showPartiesWithoutSeats);
     }
 
+    getSingleDistrictData(): DistrictResult[] {
+        const data = getDistrictTableData(this.getSeatDistributionData(), this.props.decimals);
+        const roundedData: DistrictResult[] = [];
+        data.forEach((result) => {
+            roundedData.push({
+                ...result,
+                partyResults: roundPartyResults(result.partyResults, this.props.decimals)
+            });
+        });
+        return roundedData;
+    }
+
     render() {
         switch (this.props.currentPresentation) {
             case PresentationType.ElectionTable:
@@ -56,7 +69,7 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
                 return (
                     <SingleCounty
                         districtSelected={this.props.districtSelected}
-                        districtResults={this.getSeatDistributionData()}
+                        districtResults={this.getSingleDistrictData()}
                     />
                 );
             default:

--- a/src/app/Layout/Presentation/PresentationContainer.tsx
+++ b/src/app/Layout/Presentation/PresentationContainer.tsx
@@ -8,7 +8,8 @@ const mapStateToProps = (state: RootState) => {
         results: state.computationState.results,
         currentPresentation: state.presentationState.currentPresentation,
         decimals: state.presentationState.decimalsNumber,
-        showPartiesWithoutSeats: state.presentationState.showPartiesWithoutSeats
+        showPartiesWithoutSeats: state.presentationState.showPartiesWithoutSeats,
+        districtSelected: state.presentationState.districtSelected
     } as PresentationProps;
 };
 

--- a/src/app/Layout/Presentation/Utilities/PresentationUtilities.ts
+++ b/src/app/Layout/Presentation/Utilities/PresentationUtilities.ts
@@ -91,3 +91,15 @@ export function getSeatsPerPartyData(partyResults: PartyResult[], showPartiesWit
         return partyResults.filter((party) => party.totalSeats > 0);
     }
 }
+
+export function roundPartyResults(partyResults: PartyResult[], numberOfDecimals: number): PartyResult[] {
+    const roundedResults: PartyResult[] = [];
+    partyResults.forEach((result) => {
+        roundedResults.push({
+            ...result,
+            percentVotes: roundNumber(result.percentVotes, numberOfDecimals),
+            proportionality: roundNumber(result.proportionality, numberOfDecimals)
+        });
+    });
+    return roundedResults;
+}

--- a/src/app/Layout/Presentation/Views/SingleCounty.tsx
+++ b/src/app/Layout/Presentation/Views/SingleCounty.tsx
@@ -1,0 +1,52 @@
+import { DistrictResult, PartyResult } from "../../../Layout/Interfaces/Results";
+import * as React from "react";
+import ReactTable, { Column } from "react-table";
+
+export interface SingleCountyProps {
+    districtResults: DistrictResult[];
+    districtSelected: string;
+}
+
+export class SingleCounty extends React.Component<SingleCountyProps, {}> {
+    columns: Column[] = [
+        {
+            Header: "Parti",
+            accessor: "partyCode"
+        },
+        {
+            Header: "Stemmer",
+            accessor: "votes"
+        },
+        {
+            Header: "Dis.mandater",
+            accessor: "districtSeats"
+        },
+        {
+            Header: "Utj.mandater",
+            accessor: "levelingSeats"
+        },
+        {
+            Header: "Mandater",
+            accessor: "totalSeats"
+        },
+        {
+            Header: "Prop.",
+            accessor: "proportionality"
+        }
+    ];
+
+    getData(): PartyResult[] {
+        return this.props.districtResults.find((district) => district.name === this.props.districtSelected)!
+            .partyResults;
+    }
+
+    render() {
+        const data = this.getData();
+        return (
+            <React.Fragment>
+                <h1 className="h1">{this.props.districtSelected}</h1>
+                <ReactTable className="-highlight -striped" data={data} pageSize={data.length} columns={this.columns} />
+            </React.Fragment>
+        );
+    }
+}

--- a/src/app/Layout/Presentation/Views/SingleDistrict.tsx
+++ b/src/app/Layout/Presentation/Views/SingleDistrict.tsx
@@ -1,13 +1,13 @@
-import { DistrictResult, PartyResult } from "../../../Layout/Interfaces/Results";
+import { DistrictResult, PartyResult } from "../../Interfaces/Results";
 import * as React from "react";
 import ReactTable, { Column } from "react-table";
 
-export interface SingleCountyProps {
+export interface SingleDistrictProps {
     districtResults: DistrictResult[];
     districtSelected: string;
 }
 
-export class SingleCounty extends React.Component<SingleCountyProps, {}> {
+export class SingleDistrict extends React.Component<SingleDistrictProps, {}> {
     columns: Column[] = [
         {
             Header: "Parti",

--- a/src/app/Layout/Presentation/Views/index.ts
+++ b/src/app/Layout/Presentation/Views/index.ts
@@ -2,3 +2,4 @@ export * from "./DistrictOverview";
 export * from "./ElectionOverview";
 export * from "./SeatDistribution";
 export * from "./SeatsPerParty";
+export * from "./SingleCounty";

--- a/src/app/Layout/Presentation/Views/index.ts
+++ b/src/app/Layout/Presentation/Views/index.ts
@@ -2,4 +2,4 @@ export * from "./DistrictOverview";
 export * from "./ElectionOverview";
 export * from "./SeatDistribution";
 export * from "./SeatsPerParty";
-export * from "./SingleCounty";
+export * from "./SingleDistrict";

--- a/src/app/Layout/PresentationSettings/PresentationActions.ts
+++ b/src/app/Layout/PresentationSettings/PresentationActions.ts
@@ -21,11 +21,17 @@ export interface ChangeShowPartiesNoSeat {
     showPartiesWithoutSeats: boolean;
 }
 
+export interface SelectDistrictAction {
+    type: PresentationAction.SelectDistrict;
+    districtSelected: string;
+}
+
 export type PresentationAction =
     | ChangePresentationAction
     | InitializePresentationAction
     | ChangeDecimalsAction
-    | ChangeShowPartiesNoSeat;
+    | ChangeShowPartiesNoSeat
+    | SelectDistrictAction;
 
 export function initializePresentation() {
     const action = {
@@ -43,6 +49,14 @@ export function changePresentation(presentationSelected: PresentationType) {
         type: PresentationAction.ChangePresentation,
         presentationSelected
     } as ChangePresentationAction;
+    console.log(`Action of type ${action.type} created`);
+    return action;
+}
+export function selectDistrict(name: string): SelectDistrictAction {
+    const action: SelectDistrictAction = {
+        type: PresentationAction.SelectDistrict,
+        districtSelected: name
+    };
     console.log(`Action of type ${action.type} created`);
     return action;
 }

--- a/src/app/Layout/PresentationSettings/PresentationReducer.ts
+++ b/src/app/Layout/PresentationSettings/PresentationReducer.ts
@@ -3,7 +3,7 @@ import { Action } from "redux";
 import { PresentationAction as KnownAction } from "./PresentationActions";
 import { PresentationAction } from "../Types/ActionTypes";
 
-export function presentationReducer(state: PresentationState | undefined, incomingAction: Action) {
+export function presentationReducer(state: PresentationState | undefined, incomingAction: Action): PresentationState {
     if (state === undefined) {
         state = unloadedState;
     }
@@ -18,26 +18,32 @@ export function presentationReducer(state: PresentationState | undefined, incomi
                 decimals: action.decimals,
                 decimalsNumber: action.decimalsNumber,
                 showPartiesWithoutSeats: action.showPartiesWithoutSeats
-            } as PresentationState;
+            };
         case PresentationAction.ChangePresentation:
             console.log(`Action of type ${action.type} reduced`);
             return {
                 ...state,
                 currentPresentation: action.presentationSelected
-            } as PresentationState;
+            };
         case PresentationAction.ChangeDecimals:
             console.log(`Action of type ${action.type} reduced`);
             return {
                 ...state,
                 decimals: action.decimals,
                 decimalsNumber: action.decimalsNumber
-            } as PresentationState;
+            };
         case PresentationAction.ShowPartiesNoSeats:
             console.log(`Action of type ${action.type} reduced`);
             return {
                 ...state,
                 showPartiesWithoutSeats: action.showPartiesWithoutSeats
-            } as PresentationState;
+            };
+        case PresentationAction.SelectDistrict:
+            console.log(`Action of type ${action.type} reduced`);
+            return {
+                ...state,
+                districtSelected: action.districtSelected
+            };
         default:
             console.log(`Action of type ${incomingAction.type} reduced to default`);
             return state || unloadedState;

--- a/src/app/Layout/PresentationSettings/PresentationSelection.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationSelection.tsx
@@ -38,6 +38,11 @@ export class PresentationSelection extends React.Component {
                     title={"Mandater per parti"}
                     presentationSelected={PresentationType.SeatsPerParty}
                 />
+                <PresentationSelectionButton
+                    className="btn-block"
+                    title={"Fylkestabeller"}
+                    presentationSelected={PresentationType.SingleCountyTable}
+                />
             </React.Fragment>
         );
     }

--- a/src/app/Layout/PresentationSettings/PresentationSettings.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationSettings.tsx
@@ -5,18 +5,17 @@ import { PresentationType } from "../Types/PresentationType";
 
 export interface PresentationSettingsProps {
     currentPresentation: PresentationType;
+    districtSelected: string;
     displayedDecimals?: number;
     decimals: string;
     showPartiesWithoutSeats: boolean;
     changeDecimals: (decimals: string, decimalsNumber: number) => void;
     toggleShowPartiesWithoutSeats: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    selectDistrict: (event: React.ChangeEvent<HTMLSelectElement>) => void;
     results: LagueDhontResult;
 }
 export class PresentationSettings extends React.Component<PresentationSettingsProps> {
     static defaultProps = {} as PresentationSettingsProps;
-    onChange() {
-        // TODO: Complete function
-    }
     /**
      * Helper function for reducing code in render(), allows conditional
      * rendering.
@@ -24,8 +23,16 @@ export class PresentationSettings extends React.Component<PresentationSettingsPr
     needsDecimals(): boolean {
         if (
             this.props.currentPresentation === PresentationType.DistrictTable ||
-            this.props.currentPresentation === PresentationType.ElectionTable
+            this.props.currentPresentation === PresentationType.ElectionTable ||
+            this.props.currentPresentation === PresentationType.SingleCountyTable
         ) {
+            return true;
+        }
+        return false;
+    }
+
+    needsDistrictDropdown(): boolean {
+        if (this.props.currentPresentation === PresentationType.SingleCountyTable) {
             return true;
         }
         return false;
@@ -62,6 +69,29 @@ export class PresentationSettings extends React.Component<PresentationSettingsPr
                         value={this.props.decimals}
                         onChange={this.props.changeDecimals}
                     />
+                    <div hidden={!this.needsDistrictDropdown()} className="form-row align-items-center">
+                        <div className="col-sm-4 my-1">
+                            <label className="col-form-label col-md-2" htmlFor="district">
+                                Fylke
+                            </label>
+                        </div>
+                        <div className="col-sm-8">
+                            <select
+                                id="district"
+                                onChange={this.props.selectDistrict}
+                                className="form-control"
+                                value={this.props.districtSelected}
+                            >
+                                {this.props.results.districtResults.map((item, index) => {
+                                    return (
+                                        <option key={index} value={item.name}>
+                                            {item.name}
+                                        </option>
+                                    );
+                                })}
+                            </select>
+                        </div>
+                    </div>
                 </form>
             </React.Fragment>
         );

--- a/src/app/Layout/PresentationSettings/PresentationSettings.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationSettings.tsx
@@ -31,6 +31,13 @@ export class PresentationSettings extends React.Component<PresentationSettingsPr
         return false;
     }
 
+    /**
+     * Helper function for evaluating whether the district dropdown should
+     * be shown.
+     *
+     * @returns true if the dropdown should be shown, false otherwise
+     * @memberof PresentationSettings
+     */
     needsDistrictDropdown(): boolean {
         if (this.props.currentPresentation === PresentationType.SingleCountyTable) {
             return true;

--- a/src/app/Layout/PresentationSettings/PresentationSettingsContainer.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationSettingsContainer.tsx
@@ -1,7 +1,7 @@
 import { RootState } from "../../reducers";
 import { connect } from "react-redux";
 import { PresentationSettings } from "./PresentationSettings";
-import { ChangeDecimalsAction } from "./PresentationActions";
+import { ChangeDecimalsAction, selectDistrict } from "./PresentationActions";
 import { PresentationAction } from "../Types/ActionTypes";
 
 function mapStateToProps(state: RootState) {
@@ -9,7 +9,8 @@ function mapStateToProps(state: RootState) {
         currentPresentation: state.presentationState.currentPresentation,
         decimals: state.presentationState.decimals,
         results: state.computationState.results,
-        showPartiesWithoutSeats: state.presentationState.showPartiesWithoutSeats
+        showPartiesWithoutSeats: state.presentationState.showPartiesWithoutSeats,
+        districtSelected: state.presentationState.districtSelected
     };
 }
 
@@ -26,6 +27,10 @@ const mapDispatchToProps = (dispatch: any) => ({
             type: PresentationAction.ShowPartiesNoSeats,
             showPartiesWithoutSeats: event.target.checked
         });
+    },
+    selectDistrict: (event: React.ChangeEvent<HTMLSelectElement>) => {
+        const action = selectDistrict(event.target.value);
+        dispatch(action);
     }
 });
 

--- a/src/app/Layout/PresentationSettings/PresentationState.ts
+++ b/src/app/Layout/PresentationSettings/PresentationState.ts
@@ -2,6 +2,7 @@ import { PresentationType } from "../Types/PresentationType";
 
 export interface PresentationState {
     currentPresentation: PresentationType;
+    districtSelected: string;
     decimals: string;
     decimalsNumber: number;
     showPartiesWithoutSeats: boolean;
@@ -11,5 +12,6 @@ export const unloadedState: PresentationState = {
     currentPresentation: PresentationType.ElectionTable,
     decimals: "2",
     decimalsNumber: 2,
-    showPartiesWithoutSeats: false
+    showPartiesWithoutSeats: false,
+    districtSelected: "Østfold"
 };

--- a/src/app/Layout/Types/ActionTypes.ts
+++ b/src/app/Layout/Types/ActionTypes.ts
@@ -17,5 +17,6 @@ export enum PresentationAction {
     InitializePresentation = "INITIALIZE_PRESENTATION",
     ChangePresentation = "CHANGE_PRESENTATION",
     ChangeDecimals = "CHANGE_DECIMALS",
-    ShowPartiesNoSeats = "SHOW_PARTIES_WITH_NO_SEATS"
+    ShowPartiesNoSeats = "SHOW_PARTIES_WITH_NO_SEATS",
+    SelectDistrict = "SELECT_DISTRICT"
 }

--- a/src/app/Layout/Types/PresentationType.ts
+++ b/src/app/Layout/Types/PresentationType.ts
@@ -2,5 +2,6 @@ export enum PresentationType {
     DistrictTable = "TABLE_DISTRICT_OVERVIEW",
     ElectionTable = "TABLE_ELECTION_OVERVIEW",
     SeatDistribution = "SEAT_DISTRIBUTION",
-    SeatsPerParty = "CHART_SEATS_PER_PARTY"
+    SeatsPerParty = "CHART_SEATS_PER_PARTY",
+    SingleCountyTable = "TABLE_SINGLE_COUNTY"
 }


### PR DESCRIPTION
# Description
A requested feature is to be able to view singular districts and how parties fared there. This is a first draft/attempt at that view. Be thorough in the review!
# Testing
## Setup
Make sure to use the browser console and clear the application data. State has been changed and I am unsure how that will impact your testing.
## Expected
* There is a new button for accessing single district presentation
* When clicked, a table of a single district appears in the presentation section, and relevant settings appear in presentation settings
* Changing the new dropdown select results in changing the view with accurate results
* The button opens the default (Østfold, 2017 as of now)
* State is correctly stored and loaded as in all other views
* Page size is set to the number of parties that got mandates in the election (not just in the district), keeping the view stable

Closes #14 