### PR TITLE
refactor: Use strong typing where possible

### DIFF
--- a/src/app/Layout/API/RequestedDataReducer.ts
+++ b/src/app/Layout/API/RequestedDataReducer.ts
@@ -4,9 +4,6 @@ import { RequestedDataAction } from "../Types/ActionTypes";
 
 type KnownAction = InitializeRequestedDataAction;
 
-// NB: BaseReducer Typescript (Reducer<State>) definition changes as of redux 4.0.0
-// https://github.com/rt2zz/redux-persist/pull/778
-
 export function requestedDataAction(state: RequestedDataState | undefined, action: KnownAction): RequestedDataState {
     if (state === undefined) {
         state = unloadedState;

--- a/src/app/Layout/API/RequestedDataReducer.ts
+++ b/src/app/Layout/API/RequestedDataReducer.ts
@@ -21,7 +21,7 @@ export function requestedDataAction(state: RequestedDataState | undefined, actio
                 enableAutoSave: true
             };
         default:
-            console.log(`Action of type ${action.type} reduced to default`);
+            console.log(`Action of type ${action!.type} reduced to default`);
             return state || unloadedState;
     }
 }

--- a/src/app/Layout/API/RequestedDataReducer.ts
+++ b/src/app/Layout/API/RequestedDataReducer.ts
@@ -1,5 +1,4 @@
-﻿import { Action } from "redux";
-import { InitializeRequestedDataAction } from "./RequestedDataActions";
+﻿import { InitializeRequestedDataAction } from "./RequestedDataActions";
 import { RequestedDataState, unloadedState } from "./RequestedDataState";
 import { RequestedDataAction } from "../Types/ActionTypes";
 
@@ -8,12 +7,11 @@ type KnownAction = InitializeRequestedDataAction;
 // NB: BaseReducer Typescript (Reducer<State>) definition changes as of redux 4.0.0
 // https://github.com/rt2zz/redux-persist/pull/778
 
-export function requestedDataAction(state: RequestedDataState | undefined, incomingAction: Action) {
+export function requestedDataAction(state: RequestedDataState | undefined, action: KnownAction): RequestedDataState {
     if (state === undefined) {
         state = unloadedState;
     }
 
-    const action = incomingAction as KnownAction;
     switch (action.type) {
         case RequestedDataAction.InitializeRequestedData:
             console.log(`Action of type ${action.type} reduced`);
@@ -21,9 +19,9 @@ export function requestedDataAction(state: RequestedDataState | undefined, incom
                 ...state,
                 electionType: action.electionType,
                 enableAutoSave: true
-            } as RequestedDataState;
+            };
         default:
-            console.log(`Action of type ${incomingAction.type} reduced to default`);
+            console.log(`Action of type ${action.type} reduced to default`);
             return state || unloadedState;
     }
 }

--- a/src/app/Layout/Computation/ComputationReducer.ts
+++ b/src/app/Layout/Computation/ComputationReducer.ts
@@ -4,9 +4,6 @@ import { ComputationAction as ElectionActionEnum } from "../Types/ActionTypes";
 
 type KnownAction = InitializeComputationAction | UpdateResultsAction;
 
-// NB: BaseReducer Typescript (Reducer<State>) definition changes as of redux 4.0.0
-// https://github.com/rt2zz/redux-persist/pull/778
-
 export function computationReducer(state: ComputationState | undefined, action: KnownAction): ComputationState {
     if (state === undefined) {
         state = unloadedState;

--- a/src/app/Layout/Computation/ComputationReducer.ts
+++ b/src/app/Layout/Computation/ComputationReducer.ts
@@ -1,5 +1,4 @@
-﻿import { Action } from "redux";
-import { ComputationState, unloadedState } from "./ComputationState";
+﻿import { ComputationState, unloadedState } from "./ComputationState";
 import { InitializeComputationAction, UpdateResultsAction } from "./ComputationActions";
 import { ComputationAction as ElectionActionEnum } from "../Types/ActionTypes";
 
@@ -8,12 +7,11 @@ type KnownAction = InitializeComputationAction | UpdateResultsAction;
 // NB: BaseReducer Typescript (Reducer<State>) definition changes as of redux 4.0.0
 // https://github.com/rt2zz/redux-persist/pull/778
 
-export function computationReducer(state: ComputationState | undefined, incomingAction: Action) {
+export function computationReducer(state: ComputationState | undefined, action: KnownAction): ComputationState {
     if (state === undefined) {
         state = unloadedState;
     }
 
-    const action = incomingAction as KnownAction;
     switch (action.type) {
         case ElectionActionEnum.InitializeComputation:
             console.log(`Action of type ${action.type} reduced`);
@@ -40,7 +38,7 @@ export function computationReducer(state: ComputationState | undefined, incoming
                 results: action.results
             };
         default:
-            console.log(`Action of type ${incomingAction.type} reduced to default`);
+            console.log(`Action of type ${action!.type} reduced to default`);
             return state || unloadedState;
     }
 }

--- a/src/app/Layout/ComputationSettings/SettingMenuContainer.tsx
+++ b/src/app/Layout/ComputationSettings/SettingMenuContainer.tsx
@@ -13,6 +13,13 @@ interface PropsFromState {
     electionType: ElectionType;
 }
 
+interface PropsFromDispatch {
+    updateCalculation: (computationPayload: ComputationPayload, autoCompute: boolean, forceCompute: boolean) => any;
+    updateSettings: (settingsPayload: SettingsPayload) => any;
+    toggleAutoCompute: (autoCompute: boolean) => any;
+    resetToHistoricalSettings: (settingsPayload: SettingsPayload, election: Election) => any;
+}
+
 const mapStateToProps = (state: RootState): PropsFromState => ({
     computationPayload: {
         election: state.computationState.election,
@@ -36,7 +43,7 @@ const mapStateToProps = (state: RootState): PropsFromState => ({
     electionType: state.requestedDataState.electionType
 });
 
-const mapDispatchToProps = (dispatch: any) => ({
+const mapDispatchToProps = (dispatch: any): PropsFromDispatch => ({
     updateCalculation: (computationPayload: ComputationPayload, autoCompute: boolean, forceCompute: boolean) => {
         if (autoCompute || forceCompute) {
             const payload: ComputationPayload = {

--- a/src/app/Layout/ComputationSettings/SettingMenuContainer.tsx
+++ b/src/app/Layout/ComputationSettings/SettingMenuContainer.tsx
@@ -4,10 +4,16 @@ import { SettingMenuComponent } from "./SettingMenuComponent";
 import { updateElectionData } from "../Computation";
 import { updateSettings, toggleAutoCompute } from ".";
 import { ComputationPayload, SettingsPayload } from "../Interfaces/Payloads";
-import { Election } from "../Interfaces/Models";
+import { Election, ElectionType } from "../Interfaces/Models";
 import { getAlgorithmType } from "../Logic/AlgorithmUtils";
 
-const mapStateToProps = (state: RootState) => ({
+interface PropsFromState {
+    computationPayload: ComputationPayload;
+    settingsPayload: SettingsPayload;
+    electionType: ElectionType;
+}
+
+const mapStateToProps = (state: RootState): PropsFromState => ({
     computationPayload: {
         election: state.computationState.election,
         algorithm: state.computationState.algorithm,
@@ -15,7 +21,7 @@ const mapStateToProps = (state: RootState) => ({
         electionThreshold: state.computationState.electionThreshold,
         districtSeats: state.computationState.districtSeats,
         levelingSeats: state.computationState.levelingSeats
-    } as ComputationPayload,
+    },
     settingsPayload: {
         electionYears: state.settingsState.electionYears,
         year: state.settingsState.year,
@@ -26,7 +32,7 @@ const mapStateToProps = (state: RootState) => ({
         levelingSeats: state.settingsState.levelingSeats,
         autoCompute: state.settingsState.autoCompute,
         forceCompute: false
-    } as SettingsPayload,
+    },
     electionType: state.requestedDataState.electionType
 });
 

--- a/src/app/Layout/ComputationSettings/SettingsReducer.ts
+++ b/src/app/Layout/ComputationSettings/SettingsReducer.ts
@@ -2,8 +2,6 @@ import { InitializeSettingsAction, UpdateSettingsAction, ToggleAutoComputeAction
 import { SettingsState, unloadedState } from "./SettingsState";
 import { SettingAction } from "../Types/ActionTypes";
 
-// TODO: Make actions for updates of elections etc...
-
 type KnownAction = InitializeSettingsAction | UpdateSettingsAction | ToggleAutoComputeAction;
 
 export function settingsReducer(state: SettingsState | undefined, action: KnownAction): SettingsState {

--- a/src/app/Layout/ComputationSettings/SettingsReducer.ts
+++ b/src/app/Layout/ComputationSettings/SettingsReducer.ts
@@ -6,9 +6,6 @@ import { SettingAction } from "../Types/ActionTypes";
 
 type KnownAction = InitializeSettingsAction | UpdateSettingsAction | ToggleAutoComputeAction;
 
-// NB: BaseReducer Typescript (Reducer<State>) definition changes as of redux 4.0.0
-// https://github.com/rt2zz/redux-persist/pull/778
-
 export function settingsReducer(state: SettingsState | undefined, action: KnownAction): SettingsState {
     if (state === undefined) {
         state = unloadedState;

--- a/src/app/Layout/ComputationSettings/SettingsReducer.ts
+++ b/src/app/Layout/ComputationSettings/SettingsReducer.ts
@@ -1,4 +1,3 @@
-import { Action } from "redux";
 import { InitializeSettingsAction, UpdateSettingsAction, ToggleAutoComputeAction } from "./SettingActions";
 import { SettingsState, unloadedState } from "./SettingsState";
 import { SettingAction } from "../Types/ActionTypes";
@@ -10,12 +9,11 @@ type KnownAction = InitializeSettingsAction | UpdateSettingsAction | ToggleAutoC
 // NB: BaseReducer Typescript (Reducer<State>) definition changes as of redux 4.0.0
 // https://github.com/rt2zz/redux-persist/pull/778
 
-export function settingsReducer(state: SettingsState | undefined, incomingAction: Action) {
+export function settingsReducer(state: SettingsState | undefined, action: KnownAction): SettingsState {
     if (state === undefined) {
         state = unloadedState;
     }
 
-    const action = incomingAction as KnownAction;
     switch (action.type) {
         case SettingAction.InitializeSettings:
             console.log(`Action of type ${action.type} reduced`);
@@ -29,7 +27,7 @@ export function settingsReducer(state: SettingsState | undefined, incomingAction
                 districtSeats: action.districtSeats,
                 levelingSeats: action.levelingSeats,
                 autoCompute: action.autoCompute
-            } as SettingsState;
+            };
         case SettingAction.UpdateSettings:
             console.log(`Action of type ${action.type} reduced`);
             return {
@@ -40,15 +38,15 @@ export function settingsReducer(state: SettingsState | undefined, incomingAction
                 electionThreshold: action.electionThreshold,
                 districtSeats: action.districtSeats,
                 levelingSeats: action.levelingSeats
-            } as SettingsState;
+            };
         case SettingAction.ToggleAutoCompute:
             console.log(`Action of type ${action.type} reduced`);
             return {
                 ...state,
                 autoCompute: action.autoCompute
-            } as SettingsState;
+            };
         default:
-            console.log(`Action of type ${incomingAction.type} reduced to default`);
+            console.log(`Action of type ${action!.type} reduced to default`);
             return state || unloadedState;
     }
 }

--- a/src/app/Layout/Presentation/PresentationContainer.tsx
+++ b/src/app/Layout/Presentation/PresentationContainer.tsx
@@ -2,7 +2,7 @@
 import { PresentationComponent, PresentationProps } from "./PresentationComponent";
 import { connect } from "react-redux";
 
-const mapStateToProps = (state: RootState) => {
+const mapStateToProps = (state: RootState): PresentationProps => {
     console.log("PresentationContainer mapped state to props");
     return {
         results: state.computationState.results,
@@ -10,7 +10,7 @@ const mapStateToProps = (state: RootState) => {
         decimals: state.presentationState.decimalsNumber,
         showPartiesWithoutSeats: state.presentationState.showPartiesWithoutSeats,
         districtSelected: state.presentationState.districtSelected
-    } as PresentationProps;
+    };
 };
 
 export const PresentationContainer = connect(

--- a/src/app/Layout/PresentationSettings/PresentationActions.ts
+++ b/src/app/Layout/PresentationSettings/PresentationActions.ts
@@ -33,22 +33,22 @@ export type PresentationAction =
     | ChangeShowPartiesNoSeat
     | SelectDistrictAction;
 
-export function initializePresentation() {
-    const action = {
+export function initializePresentation(): InitializePresentationAction {
+    const action: InitializePresentationAction = {
         type: PresentationAction.InitializePresentation,
         initialPresentation: PresentationType.ElectionTable,
         decimals: "2",
         decimalsNumber: 2,
         showPartiesWithoutSeats: false
-    } as InitializePresentationAction;
+    };
     console.log(`Action of type ${action.type} created`);
     return action;
 }
-export function changePresentation(presentationSelected: PresentationType) {
-    const action = {
+export function changePresentation(presentationSelected: PresentationType): ChangePresentationAction {
+    const action: ChangePresentationAction = {
         type: PresentationAction.ChangePresentation,
         presentationSelected
-    } as ChangePresentationAction;
+    };
     console.log(`Action of type ${action.type} created`);
     return action;
 }

--- a/src/app/Layout/PresentationSettings/PresentationReducer.ts
+++ b/src/app/Layout/PresentationSettings/PresentationReducer.ts
@@ -1,14 +1,12 @@
 ﻿import { unloadedState, PresentationState } from "./PresentationState";
-import { Action } from "redux";
 import { PresentationAction as KnownAction } from "./PresentationActions";
 import { PresentationAction } from "../Types/ActionTypes";
 
-export function presentationReducer(state: PresentationState | undefined, incomingAction: Action): PresentationState {
+export function presentationReducer(state: PresentationState | undefined, action: KnownAction): PresentationState {
     if (state === undefined) {
         state = unloadedState;
     }
 
-    const action = incomingAction as KnownAction;
     switch (action.type) {
         case PresentationAction.InitializePresentation:
             console.log(`Action of type ${action.type} reduced`);
@@ -45,7 +43,7 @@ export function presentationReducer(state: PresentationState | undefined, incomi
                 districtSelected: action.districtSelected
             };
         default:
-            console.log(`Action of type ${incomingAction.type} reduced to default`);
+            console.log(`Action of type ${action!.type} reduced to default`);
             return state || unloadedState;
     }
 }

--- a/src/app/Layout/PresentationSettings/PresentationSelection.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationSelection.tsx
@@ -7,9 +7,9 @@ export interface PresentationSelectionProps {
 }
 
 export class PresentationSelection extends React.Component {
-    static defaultProps = {
+    static defaultProps: PresentationSelectionProps = {
         currentSelection: PresentationType.ElectionTable
-    } as PresentationSelectionProps;
+    };
     constructor(props: PresentationSelectionProps) {
         super(props);
     }

--- a/src/app/Layout/PresentationSettings/PresentationSelectionButton.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationSelectionButton.tsx
@@ -7,7 +7,7 @@ export interface PresentationSelectionButtonProps extends ButtonProps {
 }
 
 export class PresentationSelectionButton extends Button<PresentationSelectionButtonProps> {
-    constructor(props: any) {
+    constructor(props: PresentationSelectionButtonProps) {
         super(props);
     }
     render() {

--- a/src/app/Layout/PresentationSettings/PresentationSelectionButtonContainer.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationSelectionButtonContainer.tsx
@@ -2,9 +2,9 @@
 import { connect } from "react-redux";
 import { changePresentation } from "./PresentationActions";
 
-const mapDispatchToProps = (dispatch: any, ownProps: PresentationSelectionButtonProps | undefined) => ({
+const mapDispatchToProps = (dispatch: any, ownProps: PresentationSelectionButtonProps) => ({
     onPress: () => {
-        const props = ownProps as PresentationSelectionButtonProps;
+        const props: PresentationSelectionButtonProps = ownProps;
         const action = changePresentation(props.presentationSelected);
         dispatch(action);
         console.log(`Action ${action.type} dispatched`);

--- a/src/app/Layout/PresentationSettings/PresentationSelectionButtonContainer.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationSelectionButtonContainer.tsx
@@ -2,10 +2,13 @@
 import { connect } from "react-redux";
 import { changePresentation } from "./PresentationActions";
 
-const mapDispatchToProps = (dispatch: any, ownProps: PresentationSelectionButtonProps) => ({
+interface PropsFromDispatch {
+    onPress: () => void;
+}
+
+const mapDispatchToProps = (dispatch: any, ownProps: PresentationSelectionButtonProps): PropsFromDispatch => ({
     onPress: () => {
-        const props: PresentationSelectionButtonProps = ownProps;
-        const action = changePresentation(props.presentationSelected);
+        const action = changePresentation(ownProps.presentationSelected);
         dispatch(action);
         console.log(`Action ${action.type} dispatched`);
     }

--- a/src/app/Layout/PresentationSettings/PresentationSettings.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationSettings.tsx
@@ -15,7 +15,6 @@ export interface PresentationSettingsProps {
     results: LagueDhontResult;
 }
 export class PresentationSettings extends React.Component<PresentationSettingsProps> {
-    static defaultProps = {} as PresentationSettingsProps;
     /**
      * Helper function for reducing code in render(), allows conditional
      * rendering.

--- a/src/app/Layout/PresentationSettings/PresentationSettingsContainer.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationSettingsContainer.tsx
@@ -3,8 +3,24 @@ import { connect } from "react-redux";
 import { PresentationSettings } from "./PresentationSettings";
 import { ChangeDecimalsAction, selectDistrict, ChangeShowPartiesNoSeat } from "./PresentationActions";
 import { PresentationAction } from "../Types/ActionTypes";
+import { PresentationType } from "../Types";
+import { LagueDhontResult } from "../Interfaces/Results";
 
-function mapStateToProps(state: RootState) {
+interface PropsFromState {
+    currentPresentation: PresentationType;
+    decimals: string;
+    results: LagueDhontResult;
+    showPartiesWithoutSeats: boolean;
+    districtSelected: string;
+}
+
+interface PropsFromDispatch {
+    changeDecimals: (decimals: string, decimalsNumber: number) => void;
+    toggleShowPartiesWithoutSeats: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    selectDistrict: (event: React.ChangeEvent<HTMLSelectElement>) => void;
+}
+
+function mapStateToProps(state: RootState): PropsFromState {
     return {
         currentPresentation: state.presentationState.currentPresentation,
         decimals: state.presentationState.decimals,
@@ -14,7 +30,7 @@ function mapStateToProps(state: RootState) {
     };
 }
 
-const mapDispatchToProps = (dispatch: any) => ({
+const mapDispatchToProps = (dispatch: any): PropsFromDispatch => ({
     changeDecimals: (decimals: string, decimalsNumber: number) => {
         const action: ChangeDecimalsAction = {
             type: PresentationAction.ChangeDecimals,

--- a/src/app/Layout/PresentationSettings/PresentationSettingsContainer.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationSettingsContainer.tsx
@@ -1,7 +1,7 @@
 import { RootState } from "../../reducers";
 import { connect } from "react-redux";
 import { PresentationSettings } from "./PresentationSettings";
-import { ChangeDecimalsAction, selectDistrict } from "./PresentationActions";
+import { ChangeDecimalsAction, selectDistrict, ChangeShowPartiesNoSeat } from "./PresentationActions";
 import { PresentationAction } from "../Types/ActionTypes";
 
 function mapStateToProps(state: RootState) {
@@ -16,17 +16,19 @@ function mapStateToProps(state: RootState) {
 
 const mapDispatchToProps = (dispatch: any) => ({
     changeDecimals: (decimals: string, decimalsNumber: number) => {
-        dispatch({
+        const action: ChangeDecimalsAction = {
             type: PresentationAction.ChangeDecimals,
             decimals,
             decimalsNumber
-        } as ChangeDecimalsAction);
+        };
+        dispatch(action);
     },
     toggleShowPartiesWithoutSeats: (event: React.ChangeEvent<HTMLInputElement>) => {
-        dispatch({
+        const action: ChangeShowPartiesNoSeat = {
             type: PresentationAction.ShowPartiesNoSeats,
             showPartiesWithoutSeats: event.target.checked
-        });
+        };
+        dispatch(action);
     },
     selectDistrict: (event: React.ChangeEvent<HTMLSelectElement>) => {
         const action = selectDistrict(event.target.value);


### PR DESCRIPTION
# Description
"as" is bad and we should feel bad. I have altered most of our code to use strong typing instead. Exceptions are:
* **connect(...)** because changing them requires further research
* **createStore(...)** because this whole function is witchcraft
*  **request(...)** because this function uses "as" the way it was intended

There are also a few commits that clean up comments we really have no use for.

# Testing
## Setup
Nothing special.
## Expected
The app should run as usual!

closes #18 