### PR TITLE
refactor: Use partials where useful

### DIFF
--- a/src/app/Layout/ComputationSettings/SettingMenuContainer.tsx
+++ b/src/app/Layout/ComputationSettings/SettingMenuContainer.tsx
@@ -1,26 +1,13 @@
 ﻿import { RootState } from "../../reducers";
 import { connect } from "react-redux";
-import { SettingMenuComponent } from "./SettingMenuComponent";
+import { SettingMenuComponent, SettingMenuProps } from "./SettingMenuComponent";
 import { updateElectionData } from "../Computation";
 import { updateSettings, toggleAutoCompute } from ".";
 import { ComputationPayload, SettingsPayload } from "../Interfaces/Payloads";
-import { Election, ElectionType } from "../Interfaces/Models";
+import { Election } from "../Interfaces/Models";
 import { getAlgorithmType } from "../Logic/AlgorithmUtils";
 
-interface PropsFromState {
-    computationPayload: ComputationPayload;
-    settingsPayload: SettingsPayload;
-    electionType: ElectionType;
-}
-
-interface PropsFromDispatch {
-    updateCalculation: (computationPayload: ComputationPayload, autoCompute: boolean, forceCompute: boolean) => any;
-    updateSettings: (settingsPayload: SettingsPayload) => any;
-    toggleAutoCompute: (autoCompute: boolean) => any;
-    resetToHistoricalSettings: (settingsPayload: SettingsPayload, election: Election) => any;
-}
-
-const mapStateToProps = (state: RootState): PropsFromState => ({
+const mapStateToProps = (state: RootState): Partial<SettingMenuProps> => ({
     computationPayload: {
         election: state.computationState.election,
         algorithm: state.computationState.algorithm,
@@ -43,7 +30,7 @@ const mapStateToProps = (state: RootState): PropsFromState => ({
     electionType: state.requestedDataState.electionType
 });
 
-const mapDispatchToProps = (dispatch: any): PropsFromDispatch => ({
+const mapDispatchToProps = (dispatch: any): Partial<SettingMenuProps> => ({
     updateCalculation: (computationPayload: ComputationPayload, autoCompute: boolean, forceCompute: boolean) => {
         if (autoCompute || forceCompute) {
             const payload: ComputationPayload = {

--- a/src/app/Layout/LayoutComponent.tsx
+++ b/src/app/Layout/LayoutComponent.tsx
@@ -4,9 +4,8 @@ import { SettingsMenuContainer } from "./ComputationSettings";
 import { PresentationContainer } from "./Presentation";
 import { PresentationMenu } from "./PresentationSettings";
 
-interface LayoutProps {
+export interface LayoutProps {
     initializeState: () => any;
-    initializePresentationState: () => any;
 }
 
 export class LayoutComponent extends React.Component<LayoutProps, {}> {

--- a/src/app/Layout/LayoutContainer.tsx
+++ b/src/app/Layout/LayoutContainer.tsx
@@ -1,4 +1,4 @@
-﻿import { LayoutComponent } from "./LayoutComponent";
+﻿import { LayoutComponent, LayoutProps } from "./LayoutComponent";
 import { connect } from "react-redux";
 import { initializeComputation } from "./Computation";
 import { initializePresentation } from "./PresentationSettings";
@@ -6,7 +6,7 @@ import { initializeRequestedData, request } from "./API";
 import { initializeSettings } from "./ComputationSettings";
 import { ElectionType } from "./Interfaces/Models";
 
-const mapDispatchToProps = (dispatch: any) => ({
+const mapDispatchToProps = (dispatch: any): LayoutProps => ({
     initializeState: async () => {
         const uri = "https://mandater-testing.azurewebsites.net/api/v1.0.0/no/pe?deep=true";
         const failover: ElectionType = {

--- a/src/app/Layout/PresentationSettings/PresentationSettingsContainer.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationSettingsContainer.tsx
@@ -1,26 +1,10 @@
 import { RootState } from "../../reducers";
 import { connect } from "react-redux";
-import { PresentationSettings } from "./PresentationSettings";
+import { PresentationSettings, PresentationSettingsProps } from "./PresentationSettings";
 import { ChangeDecimalsAction, selectDistrict, ChangeShowPartiesNoSeat } from "./PresentationActions";
 import { PresentationAction } from "../Types/ActionTypes";
-import { PresentationType } from "../Types";
-import { LagueDhontResult } from "../Interfaces/Results";
 
-interface PropsFromState {
-    currentPresentation: PresentationType;
-    decimals: string;
-    results: LagueDhontResult;
-    showPartiesWithoutSeats: boolean;
-    districtSelected: string;
-}
-
-interface PropsFromDispatch {
-    changeDecimals: (decimals: string, decimalsNumber: number) => void;
-    toggleShowPartiesWithoutSeats: (event: React.ChangeEvent<HTMLInputElement>) => void;
-    selectDistrict: (event: React.ChangeEvent<HTMLSelectElement>) => void;
-}
-
-function mapStateToProps(state: RootState): PropsFromState {
+function mapStateToProps(state: RootState): Partial<PresentationSettingsProps> {
     return {
         currentPresentation: state.presentationState.currentPresentation,
         decimals: state.presentationState.decimals,
@@ -30,7 +14,7 @@ function mapStateToProps(state: RootState): PropsFromState {
     };
 }
 
-const mapDispatchToProps = (dispatch: any): PropsFromDispatch => ({
+const mapDispatchToProps = (dispatch: any): Partial<PresentationSettingsProps> => ({
     changeDecimals: (decimals: string, decimalsNumber: number) => {
         const action: ChangeDecimalsAction = {
             type: PresentationAction.ChangeDecimals,


### PR DESCRIPTION
For (semi-)strong typing, and fewer lines of code, we can use [TypeScript partials](https://www.typescriptlang.org/docs/handbook/advanced-types.html) instead of new interfaces.