### PR TITLE
Add view displaying district quotients and hilighted levelling seat wins

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     },
     "dependencies": {
         "axios": "^0.18.0",
-        "bootstrap": "^4.1.1",
+        "bootstrap": "^4.1.2",
         "classnames": "^2.2.6",
         "history": "^4.7.2",
         "lodash": "^4.17.10",

--- a/src/app/Layout/Presentation/PresentationComponent.tsx
+++ b/src/app/Layout/Presentation/PresentationComponent.tsx
@@ -1,4 +1,4 @@
-﻿import * as React from "react";
+import * as React from "react";
 import { PresentationType } from "../Types/PresentationType";
 import { LagueDhontResult, PartyResult, DistrictResult } from "../Interfaces/Results";
 import { ElectionOverview, DistrictOverview, SeatsPerParty, SeatDistribution, SingleDistrict } from "./Views";
@@ -53,6 +53,14 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
             });
         });
         return roundedData;
+    }
+
+    getPartyCodes(): string[] {
+        const partyCodes: string[] = [];
+        this.props.results.partyResults.forEach((party) => {
+            partyCodes.push(party.partyCode);
+        });
+        return partyCodes;
     }
 
     render() {

--- a/src/app/Layout/Presentation/PresentationComponent.tsx
+++ b/src/app/Layout/Presentation/PresentationComponent.tsx
@@ -1,13 +1,17 @@
 ﻿import * as React from "react";
 import { PresentationType } from "../Types/PresentationType";
-import { LagueDhontResult, PartyResult, DistrictResult, PartyRestQuotients, LevelingSeat } from "../Interfaces/Results";
+import { LagueDhontResult, PartyResult, DistrictResult } from "../Interfaces/Results";
 import { ElectionOverview, DistrictOverview, SeatsPerParty, SeatDistribution, SingleDistrict } from "./Views";
 import {
     getDistrictTableData,
     getPartyTableData,
     getSeatDistributionData,
     getSeatsPerPartyData,
-    roundPartyResults
+    roundPartyResults,
+    flattenPartyRestQuotients,
+    removeSeatDuplicates,
+    sortSeatsByNumber,
+    getRoundsAssignedSeats
 } from "./Utilities/PresentationUtilities";
 import { RemainderQuotients } from "./Views/RemainderQuotients";
 
@@ -73,54 +77,10 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
     }
 
     getLevellingSeats() {
-        /**
-         * Flattens a cumbersome object
-         * @param prqs a container object that needs to be flattened
-         */
-        function flattenPartyRestQuotients(prqs: PartyRestQuotients[]): LevelingSeat[] {
-            const levellingSeats: LevelingSeat[] = [];
-            prqs.forEach((prq) => {
-                prq.levelingSeats.forEach((seat) => {
-                    levellingSeats.push(seat);
-                });
-            });
-            return levellingSeats;
-        }
-        const seats: LevelingSeat[] = [];
-        const seatRounds = flattenPartyRestQuotients(this.props.results.levelingSeatDistribution);
-        console.log("seatRounds", seatRounds);
-        seatRounds.forEach((round) => {
-            if (round.seatNumber > 0) {
-                seats.push(round);
-            }
-        });
-        function removeSeatDuplicates(seats: LevelingSeat[]): LevelingSeat[] {
-            const existingSeatsSet: Set<string> = new Set();
-            const uniqueSeats: LevelingSeat[] = [];
-            seats.forEach((seat) => {
-                if (!existingSeatsSet.has(seat.district + seat.seatNumber)) {
-                    uniqueSeats.push(seat);
-                    existingSeatsSet.add(seat.district + seat.seatNumber);
-                }
-            });
-            return uniqueSeats;
-        }
-
-        function sortSeatsByNumber(seats: LevelingSeat[]): LevelingSeat[] {
-            const sortedSeats: LevelingSeat[] = seats;
-            sortedSeats.sort((a, b) => {
-                if (a.seatNumber < b.seatNumber) {
-                    return -1;
-                } else if (a.seatNumber > b.seatNumber) {
-                    return 1;
-                } else {
-                    return 0;
-                }
-            });
-            return sortedSeats;
-        }
-        console.log("levelling seats:", sortSeatsByNumber(removeSeatDuplicates(seats)));
-        return sortSeatsByNumber(removeSeatDuplicates(seats));
+        const flattened = flattenPartyRestQuotients(this.props.results.levelingSeatDistribution);
+        const assignedSeats = getRoundsAssignedSeats(flattened);
+        const noDuplicateSeats = removeSeatDuplicates(assignedSeats);
+        return sortSeatsByNumber(noDuplicateSeats);
     }
 
     render() {

--- a/src/app/Layout/Presentation/PresentationComponent.tsx
+++ b/src/app/Layout/Presentation/PresentationComponent.tsx
@@ -71,6 +71,57 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
         return districts;
     }
 
+    getLevellingSeats() {
+        /**
+         * Flattens a cumbersome object
+         * @param prqs a container object that needs to be flattened
+         */
+        function flattenPartyRestQuotients(prqs: PartyRestQuotients[]): LevelingSeat[] {
+            const levellingSeats: LevelingSeat[] = [];
+            prqs.forEach((prq) => {
+                prq.levelingSeats.forEach((seat) => {
+                    levellingSeats.push(seat);
+                });
+            });
+            return levellingSeats;
+        }
+        const seats: LevelingSeat[] = [];
+        const seatRounds = flattenPartyRestQuotients(this.props.results.levelingSeatDistribution);
+        console.log("seatRounds", seatRounds);
+        seatRounds.forEach((round) => {
+            if (round.seatNumber > 0) {
+                seats.push(round);
+            }
+        });
+        function removeSeatDuplicates(seats: LevelingSeat[]): LevelingSeat[] {
+            const existingSeatsSet: Set<string> = new Set();
+            const uniqueSeats: LevelingSeat[] = [];
+            seats.forEach((seat) => {
+                if (!existingSeatsSet.has(seat.district + seat.seatNumber)) {
+                    uniqueSeats.push(seat);
+                    existingSeatsSet.add(seat.district + seat.seatNumber);
+                }
+            });
+            return uniqueSeats;
+        }
+
+        function sortSeatsByNumber(seats: LevelingSeat[]): LevelingSeat[] {
+            const sortedSeats: LevelingSeat[] = seats;
+            sortedSeats.sort((a, b) => {
+                if (a.seatNumber < b.seatNumber) {
+                    return -1;
+                } else if (a.seatNumber > b.seatNumber) {
+                    return 1;
+                } else {
+                    return 0;
+                }
+            });
+            return sortedSeats;
+        }
+        console.log("levelling seats:", sortSeatsByNumber(removeSeatDuplicates(seats)));
+        return sortSeatsByNumber(removeSeatDuplicates(seats));
+    }
+
     render() {
         switch (this.props.currentPresentation) {
             case PresentationType.ElectionTable:

--- a/src/app/Layout/Presentation/PresentationComponent.tsx
+++ b/src/app/Layout/Presentation/PresentationComponent.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
+﻿import * as React from "react";
 import { PresentationType } from "../Types/PresentationType";
-import { LagueDhontResult, PartyResult, DistrictResult } from "../Interfaces/Results";
+import { LagueDhontResult, PartyResult, DistrictResult, PartyRestQuotients, LevelingSeat } from "../Interfaces/Results";
 import { ElectionOverview, DistrictOverview, SeatsPerParty, SeatDistribution, SingleDistrict } from "./Views";
 import {
     getDistrictTableData,
@@ -9,6 +9,7 @@ import {
     getSeatsPerPartyData,
     roundPartyResults
 } from "./Utilities/PresentationUtilities";
+import { RemainderQuotients } from "./Views/RemainderQuotients";
 
 export interface PresentationProps {
     currentPresentation: PresentationType;
@@ -137,6 +138,16 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
                     <SingleDistrict
                         districtSelected={this.props.districtSelected}
                         districtResults={this.getSingleDistrictData()}
+                    />
+                );
+            case PresentationType.RemainderQuotients:
+                this.getLevellingSeats();
+                return (
+                    <RemainderQuotients
+                        districtResults={this.getSeatDistributionData()}
+                        levellingSeats={this.getLevellingSeats()}
+                        decimals={this.props.decimals}
+                        showPartiesWithoutSeats={this.props.showPartiesWithoutSeats}
                     />
                 );
             default:

--- a/src/app/Layout/Presentation/PresentationComponent.tsx
+++ b/src/app/Layout/Presentation/PresentationComponent.tsx
@@ -63,6 +63,14 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
         return partyCodes;
     }
 
+    getDistricts(): string[] {
+        const districts: string[] = [];
+        this.props.results.districtResults.forEach((district) => {
+            districts.push(district.name);
+        });
+        return districts;
+    }
+
     render() {
         switch (this.props.currentPresentation) {
             case PresentationType.ElectionTable:

--- a/src/app/Layout/Presentation/Utilities/PresentationUtilities.ts
+++ b/src/app/Layout/Presentation/Utilities/PresentationUtilities.ts
@@ -1,4 +1,4 @@
-import { PartyResult, DistrictResult } from "../../Interfaces/Results";
+import { PartyResult, DistrictResult, LevelingSeat, PartyRestQuotients } from "../../Interfaces/Results";
 import { roundNumber } from "./NumberUtilities";
 import { Dictionary } from "../../Interfaces/Utilities";
 
@@ -102,4 +102,78 @@ export function roundPartyResults(partyResults: PartyResult[], numberOfDecimals:
         });
     });
     return roundedResults;
+}
+
+/**
+ * This function should under no circumstances be used anywhere else than in
+ * getLevellingSeats(...) in PresentationComponent -- it is required only
+ * because of the way the data is stored, and will unquestionably backfire if
+ * used on an arbitrary, unprocessed array of these seats.
+ *
+ * @param seats seats that can have duplicates depending on how the final round
+ * is calculated
+ * @returns array of seats that have unique district - seat number combinations.
+ */
+export function removeSeatDuplicates(seats: LevelingSeat[]): LevelingSeat[] {
+    const existingSeatsSet: Set<string> = new Set();
+    const uniqueSeats: LevelingSeat[] = [];
+    seats.forEach((seat) => {
+        if (!existingSeatsSet.has(seat.district + seat.seatNumber)) {
+            uniqueSeats.push(seat);
+            existingSeatsSet.add(seat.district + seat.seatNumber);
+        }
+    });
+    return uniqueSeats;
+}
+
+/**
+ * Simple helper function that takes the levelling seats out of an array of
+ * party rest quotients  and puts them into its own array
+ *
+ * @param prqs
+ * @returns an array of levelling seats
+ */
+export function flattenPartyRestQuotients(prqs: PartyRestQuotients[]): LevelingSeat[] {
+    const levellingSeats: LevelingSeat[] = [];
+    prqs.forEach((prq) => {
+        prq.levelingSeats.forEach((seat) => {
+            levellingSeats.push(seat);
+        });
+    });
+    return levellingSeats;
+}
+
+/**
+ * Helper function that sorts seats by number.
+ *
+ * @param seats levelling seats
+ */
+export function sortSeatsByNumber(seats: LevelingSeat[]): LevelingSeat[] {
+    const sortedSeats: LevelingSeat[] = seats;
+    sortedSeats.sort((a, b) => {
+        if (a.seatNumber < b.seatNumber) {
+            return -1;
+        } else if (a.seatNumber > b.seatNumber) {
+            return 1;
+        } else {
+            return 0;
+        }
+    });
+    return sortedSeats;
+}
+
+/**
+ * Helper function that returns an array of rounds where seats were assigned
+ *
+ * @param rounds a round that may or may not have been given a seat
+ * @returns rounds in the form of actual levelling seats
+ */
+export function getRoundsAssignedSeats(rounds: LevelingSeat[]) {
+    const seats: LevelingSeat[] = [];
+    rounds.forEach((round) => {
+        if (round.seatNumber > 0) {
+            seats.push(round);
+        }
+    });
+    return seats;
 }

--- a/src/app/Layout/Presentation/Views/RemainderQuotients.tsx
+++ b/src/app/Layout/Presentation/Views/RemainderQuotients.tsx
@@ -16,10 +16,10 @@ interface SimpleDistrictResult {
     /**
      * Result
      */
-    partyResults: Nested[];
+    partyResults: LevellingSeatRound[];
 }
 
-interface Nested {
+interface LevellingSeatRound {
     partyCode: string;
     quotient: number;
     wonLevellingSeat: boolean;

--- a/src/app/Layout/Presentation/Views/RemainderQuotients.tsx
+++ b/src/app/Layout/Presentation/Views/RemainderQuotients.tsx
@@ -33,7 +33,7 @@ export interface RemainderQuotientsProps {
 }
 
 /**
- * Itereates through districtResults to flatten and filter it into a more
+ * Iterates through districtResults to flatten and filter it into a more
  * table-friendly form specific to RemainderQuotients
  *
  * @param districtResults results of a computation having been run on an

--- a/src/app/Layout/Presentation/Views/RemainderQuotients.tsx
+++ b/src/app/Layout/Presentation/Views/RemainderQuotients.tsx
@@ -76,7 +76,7 @@ export class RemainderQuotients extends React.Component<RemainderQuotientsProps>
         });
 
         /**
-         * Cross reference with levelling seats to get hilit cells
+         * Cross reference with levelling seats to get highlighted cells
          */
         this.props.levellingSeats.forEach((seat) => {
             const districtIndex = data.findIndex((entry) => entry.district === seat.district);

--- a/src/app/Layout/Presentation/Views/RemainderQuotients.tsx
+++ b/src/app/Layout/Presentation/Views/RemainderQuotients.tsx
@@ -13,10 +13,7 @@ interface SimpleDistrictResult {
      * The district, the key of the row
      */
     district: string;
-    /**
-     * Result
-     */
-    partyResults: LevellingSeatRound[];
+    levellingSeatRounds: LevellingSeatRound[];
 }
 
 interface LevellingSeatRound {
@@ -58,11 +55,11 @@ export class RemainderQuotients extends React.Component<RemainderQuotientsProps>
         this.props.districtResults.forEach((result) => {
             const current: any = {};
             current.district = result.name;
-            current.partyResults = [];
+            current.levellingSeatRounds = [];
             const lastIndex = result.districtSeatResult.length - 1;
 
             result.districtSeatResult[lastIndex].partyResults.forEach((result) => {
-                current.partyResults.push({
+                current.levellingSeatRounds.push({
                     partyCode: result.partyCode,
                     quotient: result.quotient,
                     wonLevellingSeat: false
@@ -70,7 +67,9 @@ export class RemainderQuotients extends React.Component<RemainderQuotientsProps>
             });
             const typedCurrent: SimpleDistrictResult = current;
             if (!this.props.showPartiesWithoutSeats) {
-                typedCurrent.partyResults = typedCurrent.partyResults.filter((result) => wonSeat.has(result.partyCode));
+                typedCurrent.levellingSeatRounds = typedCurrent.levellingSeatRounds.filter((result) =>
+                    wonSeat.has(result.partyCode)
+                );
             }
             data.push(typedCurrent);
         });
@@ -80,10 +79,10 @@ export class RemainderQuotients extends React.Component<RemainderQuotientsProps>
          */
         this.props.levellingSeats.forEach((seat) => {
             const districtIndex = data.findIndex((entry) => entry.district === seat.district);
-            const partyIndex = data[districtIndex].partyResults.findIndex(
+            const partyIndex = data[districtIndex].levellingSeatRounds.findIndex(
                 (result) => result.partyCode === seat.partyCode
             );
-            data[districtIndex].partyResults[partyIndex].wonLevellingSeat = true;
+            data[districtIndex].levellingSeatRounds[partyIndex].wonLevellingSeat = true;
         });
 
         return data;
@@ -93,11 +92,11 @@ export class RemainderQuotients extends React.Component<RemainderQuotientsProps>
         const data = this.makeData();
         const columns: Column[] = [];
 
-        for (let i = 0; i < data[0].partyResults.length; i++) {
-            const element = data[0].partyResults[i];
+        for (let i = 0; i < data[0].levellingSeatRounds.length; i++) {
+            const element = data[0].levellingSeatRounds[i];
             columns.push({
                 Header: element.partyCode,
-                accessor: `partyResults[${i}]`,
+                accessor: `levellingSeatRounds[${i}]`,
                 Cell: (row) => {
                     if (row.value !== undefined) {
                         return (

--- a/src/app/Layout/Presentation/Views/RemainderQuotients.tsx
+++ b/src/app/Layout/Presentation/Views/RemainderQuotients.tsx
@@ -1,0 +1,167 @@
+import * as React from "react";
+import { DistrictResult, LevelingSeat } from "../../Interfaces/Results";
+import ReactTable, { Column } from "react-table";
+
+/**
+ * Data here is represented as a simplified DistrictResult. For representing
+ * this data we need a district (because each row is essentially keyed by
+ * district), and then we need to ensure each district has a value for quotient
+ * and "wonLevellingSeat" for non-participating parties
+ */
+interface Data {
+    /**
+     * The district, the key of the row
+     */
+    district: string;
+    /**
+     * Result
+     */
+    partyResults: Nested[];
+}
+
+interface Nested {
+    partyCode: string;
+    quotient: number;
+    wonLevellingSeat: boolean;
+}
+
+export interface RemainderQuotientsProps {
+    districtResults: DistrictResult[];
+    levellingSeats: LevelingSeat[];
+    decimals: number;
+    showPartiesWithoutSeats: boolean;
+}
+
+/**
+ * Itereates through districtResults to flatten and filter it into a more
+ * table-friendly form specific to RemainderQuotients
+ *
+ * @param districtResults results of a computation having been run on an
+ * election
+ * @returns an array of data representing the last remainder from a Sainte-Lagüe
+ * or D'Hondt calculation in a given district for a given party, and whether or
+ * not they won a levelling seat in that district-party
+ */
+
+export class RemainderQuotients extends React.Component<RemainderQuotientsProps> {
+    makeData(): Data[] {
+        const data: Data[] = [];
+        const wonSeat: Set<string> = new Set();
+        const modified = this.props.districtResults;
+        if (!this.props.showPartiesWithoutSeats) {
+            modified.forEach((result) => {
+                result.partyResults.filter((result) => result.totalSeats > 0).forEach((result) => {
+                    wonSeat.add(result.partyCode);
+                });
+            });
+        }
+        this.props.districtResults.forEach((result) => {
+            const current: any = {};
+            current.district = result.name;
+            current.partyResults = [];
+            const lastIndex = result.districtSeatResult.length - 1;
+
+            result.districtSeatResult[lastIndex].partyResults.forEach((result) => {
+                current.partyResults.push({
+                    partyCode: result.partyCode,
+                    quotient: result.quotient,
+                    wonLevellingSeat: false
+                });
+            });
+            const typedCurrent: Data = current;
+            if (!this.props.showPartiesWithoutSeats) {
+                typedCurrent.partyResults = typedCurrent.partyResults.filter((result) => wonSeat.has(result.partyCode));
+            }
+            data.push(typedCurrent);
+        });
+
+        /**
+         * Cross reference with levelling seats to get hilit cells
+         */
+        this.props.levellingSeats.forEach((seat) => {
+            const districtIndex = data.findIndex((entry) => entry.district === seat.district);
+            const partyIndex = data[districtIndex].partyResults.findIndex(
+                (result) => result.partyCode === seat.partyCode
+            );
+            data[districtIndex].partyResults[partyIndex].wonLevellingSeat = true;
+        });
+
+        return data;
+    }
+
+    getColumns(): Column[] {
+        const data = this.makeData();
+        const columns: Column[] = [];
+
+        for (let i = 0; i < data[0].partyResults.length; i++) {
+            const element = data[0].partyResults[i];
+            columns.push({
+                Header: element.partyCode,
+                accessor: `partyResults[${i}]`,
+                Cell: (row) => {
+                    if (row.value !== undefined) {
+                        return (
+                            <div
+                                style={{
+                                    textAlign: "center",
+                                    color: row.value.wonLevellingSeat ? "white" : "black",
+                                    backgroundColor: row.value.wonLevellingSeat ? "#ff6e00" : "white"
+                                }}
+                            >
+                                {Number(row.value.quotient / 10000).toFixed(this.props.decimals)}
+                            </div>
+                        );
+                    } else {
+                        return (
+                            <div
+                                style={{
+                                    textAlign: "center"
+                                }}
+                            >
+                                {(0).toFixed(this.props.decimals)}
+                            </div>
+                        );
+                    }
+                },
+                sortable: false
+            });
+        }
+        columns.sort((a: Column, b: Column) => {
+            if (typeof a.Header === "string" && typeof b.Header === "string") {
+                return a.Header.localeCompare(b.Header);
+            } else {
+                return 0;
+            }
+        });
+        columns.unshift({
+            Header: "Fylker",
+            accessor: "district"
+        });
+
+        return columns;
+    }
+    render() {
+        const data = this.makeData();
+
+        return (
+            <React.Fragment>
+                <h2>{"Restkvotienter"}</h2>
+                <p style={{ textAlign: "justify" }}>
+                    {
+                        "Fylker med utjevningsmandater vist i oransje. Kvotientene er delt på 10 000 og representerer verdien ved utdeling av siste distriktsmandat i fylket for det respektive partiet."
+                    }
+                </p>
+                <ReactTable
+                    data={data}
+                    columns={this.getColumns()}
+                    defaultPageSize={8}
+                    showPageSizeOptions={false}
+                    ofText={"/"}
+                    nextText={"→"}
+                    previousText={"←"}
+                    pageText={"#"}
+                />
+            </React.Fragment>
+        );
+    }
+}

--- a/src/app/Layout/Presentation/Views/RemainderQuotients.tsx
+++ b/src/app/Layout/Presentation/Views/RemainderQuotients.tsx
@@ -154,7 +154,7 @@ export class RemainderQuotients extends React.Component<RemainderQuotientsProps>
                 <ReactTable
                     data={data}
                     columns={this.getColumns()}
-                    defaultPageSize={8}
+                    defaultPageSize={10}
                     showPageSizeOptions={false}
                     ofText={"/"}
                     nextText={"→"}

--- a/src/app/Layout/Presentation/Views/RemainderQuotients.tsx
+++ b/src/app/Layout/Presentation/Views/RemainderQuotients.tsx
@@ -148,7 +148,7 @@ export class RemainderQuotients extends React.Component<RemainderQuotientsProps>
                 <h2>{"Restkvotienter"}</h2>
                 <p style={{ textAlign: "justify" }}>
                     {
-                        "Fylker med utjevningsmandater vist i oransje. Kvotientene er delt på 10 000 og representerer verdien ved utdeling av siste distriktsmandat i fylket for det respektive partiet."
+                        "Par på formen fylke-parti med oransje celler indikerer at partiet har vunnet et utjevningsmandat i det korresponderende fylket. Kvotientene er delt på 10 000 og representerer verdien ved utdeling av siste distriktsmandat i fylket for det respektive partiet."
                     }
                 </p>
                 <ReactTable

--- a/src/app/Layout/Presentation/Views/RemainderQuotients.tsx
+++ b/src/app/Layout/Presentation/Views/RemainderQuotients.tsx
@@ -8,7 +8,7 @@ import ReactTable, { Column } from "react-table";
  * district), and then we need to ensure each district has a value for quotient
  * and "wonLevellingSeat" for non-participating parties
  */
-interface Data {
+interface SimpleDistrictResult {
     /**
      * The district, the key of the row
      */
@@ -44,8 +44,8 @@ export interface RemainderQuotientsProps {
  */
 
 export class RemainderQuotients extends React.Component<RemainderQuotientsProps> {
-    makeData(): Data[] {
-        const data: Data[] = [];
+    makeData(): SimpleDistrictResult[] {
+        const data: SimpleDistrictResult[] = [];
         const wonSeat: Set<string> = new Set();
         const modified = this.props.districtResults;
         if (!this.props.showPartiesWithoutSeats) {
@@ -68,7 +68,7 @@ export class RemainderQuotients extends React.Component<RemainderQuotientsProps>
                     wonLevellingSeat: false
                 });
             });
-            const typedCurrent: Data = current;
+            const typedCurrent: SimpleDistrictResult = current;
             if (!this.props.showPartiesWithoutSeats) {
                 typedCurrent.partyResults = typedCurrent.partyResults.filter((result) => wonSeat.has(result.partyCode));
             }

--- a/src/app/Layout/PresentationSettings/PresentationSelection.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationSelection.tsx
@@ -43,6 +43,11 @@ export class PresentationSelection extends React.Component {
                     title={"Fylkestabeller"}
                     presentationSelected={PresentationType.SingleCountyTable}
                 />
+                <PresentationSelectionButton
+                    className="btn-block"
+                    title={"Restkvotienter"}
+                    presentationSelected={PresentationType.RemainderQuotients}
+                />
             </React.Fragment>
         );
     }

--- a/src/app/Layout/PresentationSettings/PresentationSettings.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationSettings.tsx
@@ -23,7 +23,8 @@ export class PresentationSettings extends React.Component<PresentationSettingsPr
         if (
             this.props.currentPresentation === PresentationType.DistrictTable ||
             this.props.currentPresentation === PresentationType.ElectionTable ||
-            this.props.currentPresentation === PresentationType.SingleCountyTable
+            this.props.currentPresentation === PresentationType.SingleCountyTable ||
+            this.props.currentPresentation === PresentationType.RemainderQuotients
         ) {
             return true;
         }

--- a/src/app/Layout/Types/PresentationType.ts
+++ b/src/app/Layout/Types/PresentationType.ts
@@ -3,5 +3,6 @@ export enum PresentationType {
     ElectionTable = "TABLE_ELECTION_OVERVIEW",
     SeatDistribution = "SEAT_DISTRIBUTION",
     SeatsPerParty = "CHART_SEATS_PER_PARTY",
-    SingleCountyTable = "TABLE_SINGLE_COUNTY"
+    SingleCountyTable = "TABLE_SINGLE_COUNTY",
+    RemainderQuotients = "TABLE_REMAINDER_QUOTIENTS"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -663,9 +663,9 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
 
-bootstrap@^4.1.1:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.1.2.tgz#aee2a93472e61c471fc79fb475531dcbc87de326"
+bootstrap@^4.1.2:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.1.3.tgz#0eb371af2c8448e8c210411d0cb824a6409a12be"
 
 brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
# Description
Adds a new view displaying district quotients and highlighted levelling seat wins. It also includes some utility functions for future use and some for imminent use. A dependency patch was added since there is no point in waiting to fix it.

# Testing
Set it up and run it as usual, make sure to test various settings and look for errors/incongruences.
## Setup
Make sure you remember to run yarn before starting it.
## Expected
A new fancy view! Hooray!