### PR TITLE
Minor tweaks to tables

### DIFF
--- a/src/app/Layout/Presentation/PresentationComponent.tsx
+++ b/src/app/Layout/Presentation/PresentationComponent.tsx
@@ -1,4 +1,4 @@
-﻿import * as React from "react";
+import * as React from "react";
 import { PresentationType } from "../Types/PresentationType";
 import { LagueDhontResult, PartyResult, DistrictResult } from "../Interfaces/Results";
 import { ElectionOverview, DistrictOverview, SeatsPerParty, SeatDistribution, SingleDistrict } from "./Views";
@@ -86,7 +86,7 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
     render() {
         switch (this.props.currentPresentation) {
             case PresentationType.ElectionTable:
-                return <ElectionOverview partyResults={this.getPartyTableData()} />;
+                return <ElectionOverview partyResults={this.getPartyTableData()} decimals={this.props.decimals} />;
             case PresentationType.DistrictTable:
                 return <DistrictOverview districtResults={this.getDistrictTableData()} />;
             case PresentationType.SeatDistribution:

--- a/src/app/Layout/Presentation/PresentationComponent.tsx
+++ b/src/app/Layout/Presentation/PresentationComponent.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+﻿import * as React from "react";
 import { PresentationType } from "../Types/PresentationType";
 import { LagueDhontResult, PartyResult, DistrictResult } from "../Interfaces/Results";
 import { ElectionOverview, DistrictOverview, SeatsPerParty, SeatDistribution, SingleDistrict } from "./Views";
@@ -14,6 +14,7 @@ import {
     getRoundsAssignedSeats
 } from "./Utilities/PresentationUtilities";
 import { RemainderQuotients } from "./Views/RemainderQuotients";
+import { toMax } from "./Utilities/ReduceUtilities";
 
 export interface PresentationProps {
     currentPresentation: PresentationType;
@@ -76,6 +77,12 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
         return districts;
     }
 
+    getWidestDistrictWidth(): number {
+        return this.getDistricts()
+            .map((value) => value.length)
+            .reduce(toMax);
+    }
+
     getLevellingSeats() {
         const flattened = flattenPartyRestQuotients(this.props.results.levelingSeatDistribution);
         const assignedSeats = getRoundsAssignedSeats(flattened);
@@ -88,7 +95,12 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
             case PresentationType.ElectionTable:
                 return <ElectionOverview partyResults={this.getPartyTableData()} decimals={this.props.decimals} />;
             case PresentationType.DistrictTable:
-                return <DistrictOverview districtResults={this.getDistrictTableData()} />;
+                return (
+                    <DistrictOverview
+                        districtResults={this.getDistrictTableData()}
+                        districtWidth={this.getWidestDistrictWidth()}
+                    />
+                );
             case PresentationType.SeatDistribution:
                 return <SeatDistribution districtResults={this.getSeatDistributionData()} />;
             case PresentationType.SeatsPerParty:

--- a/src/app/Layout/Presentation/PresentationComponent.tsx
+++ b/src/app/Layout/Presentation/PresentationComponent.tsx
@@ -69,6 +69,14 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
         return partyCodes;
     }
 
+    getPartyNames(): string[] {
+        const partyNames: string[] = [];
+        this.props.results.partyResults.forEach((party) => {
+            partyNames.push(party.partyName);
+        });
+        return partyNames;
+    }
+
     getDistricts(): string[] {
         const districts: string[] = [];
         this.props.results.districtResults.forEach((district) => {
@@ -77,10 +85,8 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
         return districts;
     }
 
-    getWidestDistrictWidth(): number {
-        return this.getDistricts()
-            .map((value) => value.length)
-            .reduce(toMax);
+    getWidestStringWidth(strings: string[]): number {
+        return strings.map((value) => value.length).reduce(toMax);
     }
 
     getLevellingSeats() {
@@ -93,12 +99,18 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
     render() {
         switch (this.props.currentPresentation) {
             case PresentationType.ElectionTable:
-                return <ElectionOverview partyResults={this.getPartyTableData()} decimals={this.props.decimals} />;
+                return (
+                    <ElectionOverview
+                        partyResults={this.getPartyTableData()}
+                        decimals={this.props.decimals}
+                        partyNameWidth={this.getWidestStringWidth(this.getPartyNames())}
+                    />
+                );
             case PresentationType.DistrictTable:
                 return (
                     <DistrictOverview
                         districtResults={this.getDistrictTableData()}
-                        districtWidth={this.getWidestDistrictWidth()}
+                        districtWidth={this.getWidestStringWidth(this.getDistricts())}
                     />
                 );
             case PresentationType.SeatDistribution:

--- a/src/app/Layout/Presentation/PresentationComponent.tsx
+++ b/src/app/Layout/Presentation/PresentationComponent.tsx
@@ -111,6 +111,7 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
                     <DistrictOverview
                         districtResults={this.getDistrictTableData()}
                         districtWidth={this.getWidestStringWidth(this.getDistricts())}
+                        decimals={this.props.decimals}
                     />
                 );
             case PresentationType.SeatDistribution:

--- a/src/app/Layout/Presentation/PresentationComponent.tsx
+++ b/src/app/Layout/Presentation/PresentationComponent.tsx
@@ -114,7 +114,12 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
                     />
                 );
             case PresentationType.SeatDistribution:
-                return <SeatDistribution districtResults={this.getSeatDistributionData()} />;
+                return (
+                    <SeatDistribution
+                        districtResults={this.getSeatDistributionData()}
+                        districtWidth={this.getWidestStringWidth(this.getDistricts())}
+                    />
+                );
             case PresentationType.SeatsPerParty:
                 return <SeatsPerParty partyResults={this.getSeatsPerPartyData()} />;
             case PresentationType.SingleCountyTable:

--- a/src/app/Layout/Presentation/PresentationComponent.tsx
+++ b/src/app/Layout/Presentation/PresentationComponent.tsx
@@ -128,6 +128,7 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
                     <SingleDistrict
                         districtSelected={this.props.districtSelected}
                         districtResults={this.getSingleDistrictData()}
+                        decimals={this.props.decimals}
                     />
                 );
             case PresentationType.RemainderQuotients:

--- a/src/app/Layout/Presentation/PresentationComponent.tsx
+++ b/src/app/Layout/Presentation/PresentationComponent.tsx
@@ -1,4 +1,4 @@
-﻿import * as React from "react";
+import * as React from "react";
 import { PresentationType } from "../Types/PresentationType";
 import { LagueDhontResult, PartyResult, DistrictResult } from "../Interfaces/Results";
 import { ElectionOverview, DistrictOverview, SeatsPerParty, SeatDistribution, SingleDistrict } from "./Views";
@@ -85,8 +85,8 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
         return districts;
     }
 
-    getWidestStringWidth(strings: string[]): number {
-        return strings.map((value) => value.length).reduce(toMax);
+    getWidestStringWidth(strings: string[] = []): number {
+        return strings.map((value) => value.length).reduce(toMax)!;
     }
 
     getLevellingSeats() {

--- a/src/app/Layout/Presentation/Utilities/ReduceUtilities.ts
+++ b/src/app/Layout/Presentation/Utilities/ReduceUtilities.ts
@@ -1,0 +1,30 @@
+export function toSum(accumulator: number, current: number) {
+    return accumulator + current;
+}
+
+export function toMean(accumulator: number, current: number, index: number, array: number[]) {
+    accumulator += current;
+    if (index === array.length - 1) {
+        return accumulator / array.length;
+    } else {
+        return accumulator;
+    }
+}
+
+export function toAbsoluteMean(accumulator: number, current: number, index: number, array: number[]) {
+    current = current >= 0 ? current : current * -1;
+    accumulator += current;
+    if (index === array.length - 1) {
+        return accumulator / array.length;
+    } else {
+        return accumulator;
+    }
+}
+
+export function toMax(accumulator: number, current: number) {
+    return current > accumulator ? current : accumulator;
+}
+
+export function toMin(accumulator: number, current: number) {
+    return current < accumulator ? current : accumulator;
+}

--- a/src/app/Layout/Presentation/Views/DistrictOverview.tsx
+++ b/src/app/Layout/Presentation/Views/DistrictOverview.tsx
@@ -1,10 +1,11 @@
-import * as React from "react";
+﻿import * as React from "react";
 import ReactTable from "react-table";
 import { DistrictResult } from "../../Interfaces/Results";
 import { toSum, toMean, toMax, toMin } from "../Utilities/ReduceUtilities";
 
 export interface DistrictOverviewProps {
     districtResults: DistrictResult[];
+    districtWidth: number;
 }
 
 export class DistrictOverview extends React.Component<DistrictOverviewProps, {}> {
@@ -43,6 +44,7 @@ export class DistrictOverview extends React.Component<DistrictOverviewProps, {}>
                         {
                             Header: "Fylke",
                             accessor: "name",
+                            minWidth: this.props.districtWidth * 10,
                             Footer: (
                                 <span>
                                     <strong>Alle fylker</strong>

--- a/src/app/Layout/Presentation/Views/DistrictOverview.tsx
+++ b/src/app/Layout/Presentation/Views/DistrictOverview.tsx
@@ -9,85 +9,111 @@ export interface DistrictOverviewProps {
 export class DistrictOverview extends React.Component<DistrictOverviewProps, {}> {
     render() {
         const data = this.props.districtResults;
+        const highestVotingPower = data
+            .map((value) => value.votesPerSeat)
+            .reduce((acc, cur) => (cur < acc ? cur : acc));
+        const lowestVotingPower = data.map((value) => value.votesPerSeat).reduce((acc, cur) => (cur > acc ? cur : acc));
+        const averageVotingPower = data.map((value) => value.votesPerSeat).reduce((acc, cur, ind, arr) => {
+            acc += cur;
+            if (ind === arr.length - 1) {
+                return acc / arr.length;
+            } else {
+                return acc;
+            }
+        });
         return (
-            <ReactTable
-                className="-highlight -striped"
-                defaultPageSize={this.props.districtResults.length}
-                showPaginationBottom={false}
-                data={data}
-                columns={[
-                    {
-                        Header: "Fylke",
-                        accessor: "name",
-                        Footer: (
-                            <span>
-                                <strong>Alle fylker</strong>
-                            </span>
-                        )
-                    },
-                    {
-                        Header: "Stemmer",
-                        accessor: "votes",
-                        Footer: (
-                            <span>
-                                <strong>{data.map((value) => value.votes).reduce((acc, cur) => acc + cur, 0)}</strong>
-                            </span>
-                        )
-                    },
-                    {
-                        Header: "Distrikt",
-                        accessor: "districtSeats",
-                        Footer: (
-                            <span>
-                                <strong>
-                                    {data.map((value) => value.districtSeats).reduce((acc, cur) => acc + cur, 0)}
-                                </strong>
-                            </span>
-                        )
-                    },
-                    {
-                        Header: "Utjevning",
-                        accessor: "levelingSeats",
-                        Footer: (
-                            <span>
-                                <strong>
-                                    {data.map((value) => value.levelingSeats).reduce((acc, cur) => acc + cur, 0)}
-                                </strong>
-                            </span>
-                        )
-                    },
-                    {
-                        Header: "Sum",
-                        accessor: "totalSeats",
-                        Footer: (
-                            <span>
-                                <strong>
-                                    {data.map((value) => value.totalSeats).reduce((acc, cur) => acc + cur, 0)}
-                                </strong>
-                                <br />
-                            </span>
-                        )
-                    },
-                    {
-                        Header: "Stemmer/mandat",
-                        accessor: "votesPerSeat",
-                        Footer: (
-                            <span>
-                                <strong>
-                                    {data.map((value) => value.votesPerSeat).reduce((acc, cur, ind, arr) => {
-                                        acc += cur;
-                                        if (ind === arr.length - 1) {
-                                            return acc / arr.length;
-                                        } else {
-                                            return acc;
-                                        }
-                                    })}
-                                </strong>
-                            </span>
-                        )
-                    }
-                ]}
-            />
+            <React.Fragment>
+                <h2>Mandatfordeling</h2>
+                <span>
+                    {"En stemme i "}
+                    <strong>{data.find((entry) => entry.votesPerSeat === highestVotingPower)!.name}</strong>
+                    {" hadde mest innflytelse, og telte "}
+                    {((1 / highestVotingPower / (1 / averageVotingPower)) * 100).toFixed(2) + "%"}
+                    {" av en gjennomsnittlig stemme"}
+                </span>
+                <span>
+                    {", mens en stemme i "}
+                    <strong>{data.find((entry) => entry.votesPerSeat === lowestVotingPower)!.name}</strong>
+                    {" hadde minst innflytelse, og bare telte "}
+                    {((1 / lowestVotingPower / (1 / averageVotingPower)) * 100).toFixed(2) + "%!"}
+                    {" En stemme i det mest innflytelsesrike fylket telte altså "}
+                    {((1 / highestVotingPower / (1 / lowestVotingPower)) * 100).toFixed(2) + "%"}
+                    {" mer enn en stemme i det minst innflytelsesrike fylket."}
+                </span>
+                <br />
+                <br />
+                <ReactTable
+                    className="-highlight -striped"
+                    defaultPageSize={this.props.districtResults.length}
+                    showPaginationBottom={false}
+                    data={data}
+                    columns={[
+                        {
+                            Header: "Fylke",
+                            accessor: "name",
+                            Footer: (
+                                <span>
+                                    <strong>Alle fylker</strong>
+                                </span>
+                            )
+                        },
+                        {
+                            Header: "Stemmer",
+                            accessor: "votes",
+                            Footer: (
+                                <span>
+                                    <strong>
+                                        {data.map((value) => value.votes).reduce((acc, cur) => acc + cur, 0)}
+                                    </strong>
+                                </span>
+                            )
+                        },
+                        {
+                            Header: "Distrikt",
+                            accessor: "districtSeats",
+                            Footer: (
+                                <span>
+                                    <strong>
+                                        {data.map((value) => value.districtSeats).reduce((acc, cur) => acc + cur, 0)}
+                                    </strong>
+                                </span>
+                            )
+                        },
+                        {
+                            Header: "Utjevning",
+                            accessor: "levelingSeats",
+                            Footer: (
+                                <span>
+                                    <strong>
+                                        {data.map((value) => value.levelingSeats).reduce((acc, cur) => acc + cur, 0)}
+                                    </strong>
+                                </span>
+                            )
+                        },
+                        {
+                            Header: "Sum",
+                            accessor: "totalSeats",
+                            Footer: (
+                                <span>
+                                    <strong>
+                                        {data.map((value) => value.totalSeats).reduce((acc, cur) => acc + cur, 0)}
+                                    </strong>
+                                    <br />
+                                </span>
+                            )
+                        },
+                        {
+                            Header: "Stemmer/mandat",
+                            accessor: "votesPerSeat",
+                            Footer: (
+                                <span>
+                                    <strong>{averageVotingPower}</strong>
+                                </span>
+                            )
+                        }
+                    ]}
+                />
+            </React.Fragment>
         );
     }
 }

--- a/src/app/Layout/Presentation/Views/DistrictOverview.tsx
+++ b/src/app/Layout/Presentation/Views/DistrictOverview.tsx
@@ -24,10 +24,6 @@ export class DistrictOverview extends React.Component<DistrictOverviewProps, {}>
                         accessor: "votes"
                     },
                     {
-                        Header: "Prosent",
-                        accessor: "percentVotes"
-                    },
-                    {
                         Header: "Distrikt",
                         accessor: "districtSeats"
                     },

--- a/src/app/Layout/Presentation/Views/DistrictOverview.tsx
+++ b/src/app/Layout/Presentation/Views/DistrictOverview.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+﻿import * as React from "react";
 import ReactTable from "react-table";
 import { DistrictResult } from "../../Interfaces/Results";
 import { toSum, toMean, toMax, toMin } from "../Utilities/ReduceUtilities";
@@ -6,6 +6,7 @@ import { toSum, toMean, toMax, toMin } from "../Utilities/ReduceUtilities";
 export interface DistrictOverviewProps {
     districtResults: DistrictResult[];
     districtWidth: number;
+    decimals: number;
 }
 
 export class DistrictOverview extends React.Component<DistrictOverviewProps, {}> {
@@ -14,9 +15,9 @@ export class DistrictOverview extends React.Component<DistrictOverviewProps, {}>
         const highestVotingPower = data.map((value) => value.votesPerSeat).reduce(toMin);
         const lowestVotingPower = data.map((value) => value.votesPerSeat).reduce(toMax);
         const averageVotingPower = data.map((value) => value.votesPerSeat).reduce(toMean);
-        const highestVsAverageInPercentage = ((1 / highestVotingPower / (1 / averageVotingPower)) * 100)
-        const lowestVsAverageInPercentage = ((1 / lowestVotingPower / (1 / averageVotingPower)) * 100)
-        const highestVsLowestInPercentage = ((1 / highestVotingPower / (1 / lowestVotingPower)) * 100)
+        const highestVsAverageInPercentage = (1 / highestVotingPower / (1 / averageVotingPower)) * 100;
+        const lowestVsAverageInPercentage = (1 / lowestVotingPower / (1 / averageVotingPower)) * 100;
+        const highestVsLowestInPercentage = (1 / highestVotingPower / (1 / lowestVotingPower)) * 100;
         return (
             <React.Fragment>
                 <h2>Fylkesoversikt</h2>

--- a/src/app/Layout/Presentation/Views/DistrictOverview.tsx
+++ b/src/app/Layout/Presentation/Views/DistrictOverview.tsx
@@ -16,7 +16,7 @@ export class DistrictOverview extends React.Component<DistrictOverviewProps, {}>
         const averageVotingPower = data.map((value) => value.votesPerSeat).reduce(toMean);
         return (
             <React.Fragment>
-                <h2>Mandatfordeling</h2>
+                <h2>Fylkesoversikt</h2>
                 <span>
                     {"En stemme i "}
                     <strong>{data.find((entry) => entry.votesPerSeat === highestVotingPower)!.name}</strong>

--- a/src/app/Layout/Presentation/Views/DistrictOverview.tsx
+++ b/src/app/Layout/Presentation/Views/DistrictOverview.tsx
@@ -11,7 +11,7 @@ export class DistrictOverview extends React.Component<DistrictOverviewProps, {}>
         return (
             <ReactTable
                 className="-highlight -striped"
-                defaultPageSize={19}
+                defaultPageSize={this.props.districtResults.length}
                 showPaginationBottom={false}
                 data={this.props.districtResults}
                 columns={[

--- a/src/app/Layout/Presentation/Views/DistrictOverview.tsx
+++ b/src/app/Layout/Presentation/Views/DistrictOverview.tsx
@@ -8,36 +8,83 @@ export interface DistrictOverviewProps {
 
 export class DistrictOverview extends React.Component<DistrictOverviewProps, {}> {
     render() {
+        const data = this.props.districtResults;
         return (
             <ReactTable
                 className="-highlight -striped"
                 defaultPageSize={this.props.districtResults.length}
                 showPaginationBottom={false}
-                data={this.props.districtResults}
+                data={data}
                 columns={[
                     {
                         Header: "Fylke",
-                        accessor: "name"
+                        accessor: "name",
+                        Footer: (
+                            <span>
+                                <strong>Alle fylker</strong>
+                            </span>
+                        )
                     },
                     {
                         Header: "Stemmer",
-                        accessor: "votes"
+                        accessor: "votes",
+                        Footer: (
+                            <span>
+                                <strong>{data.map((value) => value.votes).reduce((acc, cur) => acc + cur, 0)}</strong>
+                            </span>
+                        )
                     },
                     {
                         Header: "Distrikt",
-                        accessor: "districtSeats"
+                        accessor: "districtSeats",
+                        Footer: (
+                            <span>
+                                <strong>
+                                    {data.map((value) => value.districtSeats).reduce((acc, cur) => acc + cur, 0)}
+                                </strong>
+                            </span>
+                        )
                     },
                     {
                         Header: "Utjevning",
-                        accessor: "levelingSeats"
+                        accessor: "levelingSeats",
+                        Footer: (
+                            <span>
+                                <strong>
+                                    {data.map((value) => value.levelingSeats).reduce((acc, cur) => acc + cur, 0)}
+                                </strong>
+                            </span>
+                        )
                     },
                     {
                         Header: "Sum",
-                        accessor: "totalSeats"
+                        accessor: "totalSeats",
+                        Footer: (
+                            <span>
+                                <strong>
+                                    {data.map((value) => value.totalSeats).reduce((acc, cur) => acc + cur, 0)}
+                                </strong>
+                                <br />
+                            </span>
+                        )
                     },
                     {
                         Header: "Stemmer/mandat",
-                        accessor: "votesPerSeat"
+                        accessor: "votesPerSeat",
+                        Footer: (
+                            <span>
+                                <strong>
+                                    {data.map((value) => value.votesPerSeat).reduce((acc, cur, ind, arr) => {
+                                        acc += cur;
+                                        if (ind === arr.length - 1) {
+                                            return acc / arr.length;
+                                        } else {
+                                            return acc;
+                                        }
+                                    })}
+                                </strong>
+                            </span>
+                        )
                     }
                 ]}
             />

--- a/src/app/Layout/Presentation/Views/DistrictOverview.tsx
+++ b/src/app/Layout/Presentation/Views/DistrictOverview.tsx
@@ -1,6 +1,7 @@
-﻿import * as React from "react";
+import * as React from "react";
 import ReactTable from "react-table";
 import { DistrictResult } from "../../Interfaces/Results";
+import { toSum, toMean, toMax, toMin } from "../Utilities/ReduceUtilities";
 
 export interface DistrictOverviewProps {
     districtResults: DistrictResult[];
@@ -9,18 +10,9 @@ export interface DistrictOverviewProps {
 export class DistrictOverview extends React.Component<DistrictOverviewProps, {}> {
     render() {
         const data = this.props.districtResults;
-        const highestVotingPower = data
-            .map((value) => value.votesPerSeat)
-            .reduce((acc, cur) => (cur < acc ? cur : acc));
-        const lowestVotingPower = data.map((value) => value.votesPerSeat).reduce((acc, cur) => (cur > acc ? cur : acc));
-        const averageVotingPower = data.map((value) => value.votesPerSeat).reduce((acc, cur, ind, arr) => {
-            acc += cur;
-            if (ind === arr.length - 1) {
-                return acc / arr.length;
-            } else {
-                return acc;
-            }
-        });
+        const highestVotingPower = data.map((value) => value.votesPerSeat).reduce(toMin);
+        const lowestVotingPower = data.map((value) => value.votesPerSeat).reduce(toMax);
+        const averageVotingPower = data.map((value) => value.votesPerSeat).reduce(toMean);
         return (
             <React.Fragment>
                 <h2>Mandatfordeling</h2>
@@ -62,9 +54,7 @@ export class DistrictOverview extends React.Component<DistrictOverviewProps, {}>
                             accessor: "votes",
                             Footer: (
                                 <span>
-                                    <strong>
-                                        {data.map((value) => value.votes).reduce((acc, cur) => acc + cur, 0)}
-                                    </strong>
+                                    <strong>{data.map((value) => value.votes).reduce(toSum, 0)}</strong>
                                 </span>
                             )
                         },
@@ -73,9 +63,7 @@ export class DistrictOverview extends React.Component<DistrictOverviewProps, {}>
                             accessor: "districtSeats",
                             Footer: (
                                 <span>
-                                    <strong>
-                                        {data.map((value) => value.districtSeats).reduce((acc, cur) => acc + cur, 0)}
-                                    </strong>
+                                    <strong>{data.map((value) => value.districtSeats).reduce(toSum, 0)}</strong>
                                 </span>
                             )
                         },
@@ -84,9 +72,7 @@ export class DistrictOverview extends React.Component<DistrictOverviewProps, {}>
                             accessor: "levelingSeats",
                             Footer: (
                                 <span>
-                                    <strong>
-                                        {data.map((value) => value.levelingSeats).reduce((acc, cur) => acc + cur, 0)}
-                                    </strong>
+                                    <strong>{data.map((value) => value.levelingSeats).reduce(toSum, 0)}</strong>
                                 </span>
                             )
                         },
@@ -95,9 +81,7 @@ export class DistrictOverview extends React.Component<DistrictOverviewProps, {}>
                             accessor: "totalSeats",
                             Footer: (
                                 <span>
-                                    <strong>
-                                        {data.map((value) => value.totalSeats).reduce((acc, cur) => acc + cur, 0)}
-                                    </strong>
+                                    <strong>{data.map((value) => value.totalSeats).reduce(toSum, 0)}</strong>
                                     <br />
                                 </span>
                             )

--- a/src/app/Layout/Presentation/Views/DistrictOverview.tsx
+++ b/src/app/Layout/Presentation/Views/DistrictOverview.tsx
@@ -1,4 +1,4 @@
-﻿import * as React from "react";
+import * as React from "react";
 import ReactTable from "react-table";
 import { DistrictResult } from "../../Interfaces/Results";
 import { toSum, toMean, toMax, toMin } from "../Utilities/ReduceUtilities";
@@ -14,6 +14,9 @@ export class DistrictOverview extends React.Component<DistrictOverviewProps, {}>
         const highestVotingPower = data.map((value) => value.votesPerSeat).reduce(toMin);
         const lowestVotingPower = data.map((value) => value.votesPerSeat).reduce(toMax);
         const averageVotingPower = data.map((value) => value.votesPerSeat).reduce(toMean);
+        const highestVsAverageInPercentage = ((1 / highestVotingPower / (1 / averageVotingPower)) * 100)
+        const lowestVsAverageInPercentage = ((1 / lowestVotingPower / (1 / averageVotingPower)) * 100)
+        const highestVsLowestInPercentage = ((1 / highestVotingPower / (1 / lowestVotingPower)) * 100)
         return (
             <React.Fragment>
                 <h2>Fylkesoversikt</h2>
@@ -21,16 +24,16 @@ export class DistrictOverview extends React.Component<DistrictOverviewProps, {}>
                     {"En stemme i "}
                     <strong>{data.find((entry) => entry.votesPerSeat === highestVotingPower)!.name}</strong>
                     {" hadde mest innflytelse, og telte "}
-                    {((1 / highestVotingPower / (1 / averageVotingPower)) * 100).toFixed(2) + "%"}
+                    {highestVsAverageInPercentage.toFixed(2) + "%"}
                     {" av en gjennomsnittlig stemme"}
                 </span>
                 <span>
                     {", mens en stemme i "}
                     <strong>{data.find((entry) => entry.votesPerSeat === lowestVotingPower)!.name}</strong>
                     {" hadde minst innflytelse, og bare telte "}
-                    {((1 / lowestVotingPower / (1 / averageVotingPower)) * 100).toFixed(2) + "%!"}
+                    {lowestVsAverageInPercentage.toFixed(2) + "%!"}
                     {" En stemme i det mest innflytelsesrike fylket telte altså "}
-                    {((1 / highestVotingPower / (1 / lowestVotingPower)) * 100).toFixed(2) + "%"}
+                    {highestVsLowestInPercentage.toFixed(2) + "%"}
                     {" mer enn en stemme i det minst innflytelsesrike fylket."}
                 </span>
                 <br />

--- a/src/app/Layout/Presentation/Views/DistrictOverview.tsx
+++ b/src/app/Layout/Presentation/Views/DistrictOverview.tsx
@@ -12,6 +12,7 @@ export interface DistrictOverviewProps {
 export class DistrictOverview extends React.Component<DistrictOverviewProps, {}> {
     render() {
         const data = this.props.districtResults;
+        const decimals = this.props.decimals;
         const highestVotingPower = data.map((value) => value.votesPerSeat).reduce(toMin);
         const lowestVotingPower = data.map((value) => value.votesPerSeat).reduce(toMax);
         const averageVotingPower = data.map((value) => value.votesPerSeat).reduce(toMean);
@@ -25,16 +26,16 @@ export class DistrictOverview extends React.Component<DistrictOverviewProps, {}>
                     {"En stemme i "}
                     <strong>{data.find((entry) => entry.votesPerSeat === highestVotingPower)!.name}</strong>
                     {" hadde mest innflytelse, og telte "}
-                    {highestVsAverageInPercentage.toFixed(2) + "%"}
+                    {highestVsAverageInPercentage.toFixed(decimals) + "%"}
                     {" av en gjennomsnittlig stemme"}
                 </span>
                 <span>
                     {", mens en stemme i "}
                     <strong>{data.find((entry) => entry.votesPerSeat === lowestVotingPower)!.name}</strong>
                     {" hadde minst innflytelse, og bare telte "}
-                    {lowestVsAverageInPercentage.toFixed(2) + "%!"}
+                    {lowestVsAverageInPercentage.toFixed(decimals) + "%!"}
                     {" En stemme i det mest innflytelsesrike fylket telte altså "}
-                    {highestVsLowestInPercentage.toFixed(2) + "%"}
+                    {highestVsLowestInPercentage.toFixed(decimals) + "%"}
                     {" mer enn en stemme i det minst innflytelsesrike fylket."}
                 </span>
                 <br />
@@ -97,7 +98,7 @@ export class DistrictOverview extends React.Component<DistrictOverviewProps, {}>
                             accessor: "votesPerSeat",
                             Footer: (
                                 <span>
-                                    <strong>{averageVotingPower}</strong>
+                                    <strong>{averageVotingPower.toFixed(decimals)}</strong>
                                 </span>
                             )
                         }

--- a/src/app/Layout/Presentation/Views/ElectionOverview.tsx
+++ b/src/app/Layout/Presentation/Views/ElectionOverview.tsx
@@ -34,30 +34,34 @@ export class ElectionOverview extends React.Component<ElectionOverviewProps, {}>
                     {
                         Header: "Stemmer",
                         accessor: "votes",
-                        Footer: data.map((value) => value.votes).reduce(toSum)
+                        Footer: <strong>{data.map((value) => value.votes).reduce(toSum)}</strong>
                     },
                     {
                         Header: "Distrikt",
                         accessor: "districtSeats",
-                        Footer: data.map((value) => value.districtSeats).reduce(toSum)
+                        Footer: <strong>{data.map((value) => value.districtSeats).reduce(toSum)}</strong>
                     },
                     {
                         Header: "Utjevning",
                         accessor: "levelingSeats",
-                        Footer: data.map((value) => value.levelingSeats).reduce(toSum)
+                        Footer: <strong>{data.map((value) => value.levelingSeats).reduce(toSum)}</strong>
                     },
                     {
                         Header: "Sum",
                         accessor: "totalSeats",
-                        Footer: data.map((value) => value.totalSeats).reduce(toSum)
+                        Footer: <strong>{data.map((value) => value.totalSeats).reduce(toSum)}</strong>
                     },
                     {
                         Header: "Proporsjonalitet",
                         accessor: "proportionality",
-                        Footer: data
-                            .map((value) => value.proportionality)
-                            .reduce(toSum)
-                            .toFixed(this.props.decimals)
+                        Footer: (
+                            <strong>
+                                {data
+                                    .map((value) => value.proportionality)
+                                    .reduce(toSum)
+                                    .toFixed(this.props.decimals)}
+                            </strong>
+                        )
                     }
                 ]}
                 defaultSorted={[

--- a/src/app/Layout/Presentation/Views/ElectionOverview.tsx
+++ b/src/app/Layout/Presentation/Views/ElectionOverview.tsx
@@ -6,6 +6,7 @@ import { toSum } from "../Utilities/ReduceUtilities";
 export interface ElectionOverviewProps {
     partyResults: PartyResult[];
     decimals: number;
+    partyNameWidth: number;
 }
 
 export class ElectionOverview extends React.Component<ElectionOverviewProps, {}> {
@@ -27,6 +28,7 @@ export class ElectionOverview extends React.Component<ElectionOverviewProps, {}>
                     {
                         Header: "Parti",
                         accessor: "partyName",
+                        width: this.props.partyNameWidth * 8,
                         Footer: <strong>Utvalg</strong>
                     },
                     {

--- a/src/app/Layout/Presentation/Views/ElectionOverview.tsx
+++ b/src/app/Layout/Presentation/Views/ElectionOverview.tsx
@@ -13,13 +13,11 @@ export class ElectionOverview extends React.Component<ElectionOverviewProps, {}>
                 className="-highlight -striped"
                 data={this.props.partyResults}
                 defaultPageSize={10}
-                showPaginationBottom={false}
-                showPaginationTop={true}
-                rowsText="rader"
-                pageText="Side"
-                ofText="av"
-                nextText="Neste"
-                previousText="Forrige"
+                showPageSizeOptions={false}
+                ofText={"/"}
+                nextText={"→"}
+                previousText={"←"}
+                pageText={"#"}
                 columns={[
                     {
                         Header: "Parti",

--- a/src/app/Layout/Presentation/Views/ElectionOverview.tsx
+++ b/src/app/Layout/Presentation/Views/ElectionOverview.tsx
@@ -8,11 +8,14 @@ export interface ElectionOverviewProps {
 
 export class ElectionOverview extends React.Component<ElectionOverviewProps, {}> {
     render() {
+        const data = this.props.partyResults;
         return (
             <ReactTable
                 className="-highlight -striped"
-                data={this.props.partyResults}
-                defaultPageSize={10}
+                data={data}
+                defaultPageSize={data.length >= 10 ? 10 : data.length}
+                pageSize={data.length >= 10 ? 10 : data.length}
+                showPagination={data.length > 10}
                 showPageSizeOptions={false}
                 ofText={"/"}
                 nextText={"→"}
@@ -26,10 +29,6 @@ export class ElectionOverview extends React.Component<ElectionOverviewProps, {}>
                     {
                         Header: "Stemmer",
                         accessor: "votes"
-                    },
-                    {
-                        Header: "Prosent",
-                        accessor: "percentVotes"
                     },
                     {
                         Header: "Distrikt",

--- a/src/app/Layout/Presentation/Views/ElectionOverview.tsx
+++ b/src/app/Layout/Presentation/Views/ElectionOverview.tsx
@@ -1,6 +1,7 @@
-import * as React from "react";
+﻿import * as React from "react";
 import ReactTable from "react-table";
 import { PartyResult } from "../../Interfaces/Results";
+import { toSum } from "../Utilities/ReduceUtilities";
 
 export interface ElectionOverviewProps {
     partyResults: PartyResult[];
@@ -25,27 +26,36 @@ export class ElectionOverview extends React.Component<ElectionOverviewProps, {}>
                 columns={[
                     {
                         Header: "Parti",
-                        accessor: "partyName"
+                        accessor: "partyName",
+                        Footer: <strong>Utvalg</strong>
                     },
                     {
                         Header: "Stemmer",
-                        accessor: "votes"
+                        accessor: "votes",
+                        Footer: data.map((value) => value.votes).reduce(toSum)
                     },
                     {
                         Header: "Distrikt",
-                        accessor: "districtSeats"
+                        accessor: "districtSeats",
+                        Footer: data.map((value) => value.districtSeats).reduce(toSum)
                     },
                     {
                         Header: "Utjevning",
-                        accessor: "levelingSeats"
+                        accessor: "levelingSeats",
+                        Footer: data.map((value) => value.levelingSeats).reduce(toSum)
                     },
                     {
                         Header: "Sum",
-                        accessor: "totalSeats"
+                        accessor: "totalSeats",
+                        Footer: data.map((value) => value.totalSeats).reduce(toSum)
                     },
                     {
                         Header: "Proporsjonalitet",
-                        accessor: "proportionality"
+                        accessor: "proportionality",
+                        Footer: data
+                            .map((value) => value.proportionality)
+                            .reduce(toSum)
+                            .toFixed(this.props.decimals)
                     }
                 ]}
                 defaultSorted={[

--- a/src/app/Layout/Presentation/Views/ElectionOverview.tsx
+++ b/src/app/Layout/Presentation/Views/ElectionOverview.tsx
@@ -1,9 +1,10 @@
-﻿import * as React from "react";
+import * as React from "react";
 import ReactTable from "react-table";
 import { PartyResult } from "../../Interfaces/Results";
 
 export interface ElectionOverviewProps {
     partyResults: PartyResult[];
+    decimals: number;
 }
 
 export class ElectionOverview extends React.Component<ElectionOverviewProps, {}> {

--- a/src/app/Layout/Presentation/Views/SeatDistribution.tsx
+++ b/src/app/Layout/Presentation/Views/SeatDistribution.tsx
@@ -34,13 +34,16 @@ export class SeatDistribution extends React.Component<SeatDistributionProps, {}>
 
     render() {
         return (
-            <ReactTable
-                className="-highlight -striped"
-                defaultPageSize={19}
-                showPaginationBottom={false}
-                data={this.props.districtResults}
-                columns={this.generateColumns()}
-            />
+            <React.Fragment>
+                <h2>Mandatfordeling</h2>
+                <ReactTable
+                    className="-highlight -striped"
+                    defaultPageSize={19}
+                    showPaginationBottom={false}
+                    data={this.props.districtResults}
+                    columns={this.generateColumns()}
+                />
+            </React.Fragment>
         );
     }
 }

--- a/src/app/Layout/Presentation/Views/SeatDistribution.tsx
+++ b/src/app/Layout/Presentation/Views/SeatDistribution.tsx
@@ -4,6 +4,7 @@ import { DistrictResult } from "../../Interfaces/Results";
 
 export interface SeatDistributionProps {
     districtResults: DistrictResult[];
+    districtWidth: number;
 }
 
 export class SeatDistribution extends React.Component<SeatDistributionProps, {}> {
@@ -11,7 +12,8 @@ export class SeatDistribution extends React.Component<SeatDistributionProps, {}>
         const columns: Column[] = [
             {
                 Header: "Fylke",
-                accessor: "name"
+                accessor: "name",
+                width: this.props.districtWidth * 10
             }
         ];
 
@@ -24,7 +26,8 @@ export class SeatDistribution extends React.Component<SeatDistributionProps, {}>
                 const element = this.props.districtResults[0].partyResults[partyIndex];
                 columns.push({
                     Header: element.partyCode,
-                    accessor: `partyResults[${partyIndex}].totalSeats`
+                    accessor: `partyResults[${partyIndex}].totalSeats`,
+                    minWidth: 50
                 });
             }
         }

--- a/src/app/Layout/Presentation/Views/SingleDistrict.tsx
+++ b/src/app/Layout/Presentation/Views/SingleDistrict.tsx
@@ -45,7 +45,18 @@ export class SingleDistrict extends React.Component<SingleDistrictProps, {}> {
         return (
             <React.Fragment>
                 <h1 className="h1">{this.props.districtSelected}</h1>
-                <ReactTable className="-highlight -striped" data={data} pageSize={data.length} columns={this.columns} />
+                <ReactTable
+                    className="-highlight -striped"
+                    data={data}
+                    pageSize={data.length <= 10 ? data.length : 10}
+                    showPagination={data.length > 10}
+                    columns={this.columns}
+                    showPageSizeOptions={false}
+                    ofText={"/"}
+                    nextText={"→"}
+                    previousText={"←"}
+                    pageText={"#"}
+                />
             </React.Fragment>
         );
     }

--- a/src/app/Layout/Presentation/Views/SingleDistrict.tsx
+++ b/src/app/Layout/Presentation/Views/SingleDistrict.tsx
@@ -1,6 +1,7 @@
 import { DistrictResult, PartyResult } from "../../Interfaces/Results";
 import * as React from "react";
-import ReactTable, { Column } from "react-table";
+import ReactTable from "react-table";
+import { toSum } from "../Utilities/ReduceUtilities";
 
 export interface SingleDistrictProps {
     districtResults: DistrictResult[];
@@ -8,33 +9,6 @@ export interface SingleDistrictProps {
 }
 
 export class SingleDistrict extends React.Component<SingleDistrictProps, {}> {
-    columns: Column[] = [
-        {
-            Header: "Parti",
-            accessor: "partyCode"
-        },
-        {
-            Header: "Stemmer",
-            accessor: "votes"
-        },
-        {
-            Header: "Dis.mandater",
-            accessor: "districtSeats"
-        },
-        {
-            Header: "Utj.mandater",
-            accessor: "levelingSeats"
-        },
-        {
-            Header: "Mandater",
-            accessor: "totalSeats"
-        },
-        {
-            Header: "Prop.",
-            accessor: "proportionality"
-        }
-    ];
-
     getData(): PartyResult[] {
         return this.props.districtResults.find((district) => district.name === this.props.districtSelected)!
             .partyResults;
@@ -50,7 +24,68 @@ export class SingleDistrict extends React.Component<SingleDistrictProps, {}> {
                     data={data}
                     pageSize={data.length <= 10 ? data.length : 10}
                     showPagination={data.length > 10}
-                    columns={this.columns}
+                    columns={[
+                        {
+                            Header: "Parti",
+                            accessor: "partyCode",
+                            Footer: (
+                                <span>
+                                    <strong>Utvalg</strong>
+                                </span>
+                            )
+                        },
+                        {
+                            Header: "Stemmer",
+                            accessor: "votes",
+                            Footer: (
+                                <span>
+                                    <strong>{data.map((value) => value.votes).reduce(toSum)}</strong>
+                                </span>
+                            )
+                        },
+                        {
+                            Header: "Mandater",
+                            accessor: "totalSeats",
+                            columns: [
+                                {
+                                    Header: "Distrikt",
+                                    accessor: "districtSeats",
+                                    Footer: (
+                                        <span>
+                                            <strong>{data.map((value) => value.districtSeats).reduce(toSum)}</strong>
+                                        </span>
+                                    )
+                                },
+                                {
+                                    Header: "Utjevning",
+                                    accessor: "levelingSeats",
+                                    Footer: (
+                                        <span>
+                                            <strong>{data.map((value) => value.levelingSeats).reduce(toSum)}</strong>
+                                        </span>
+                                    )
+                                }
+                            ]
+                        },
+                        {
+                            Header: "Mandater",
+                            accessor: "totalSeats",
+                            Footer: (
+                                <span>
+                                    <strong>{data.map((value) => value.totalSeats).reduce(toSum)}</strong>
+                                </span>
+                            )
+                        },
+                        {
+                            Header: "Prop.",
+                            accessor: "proportionality",
+                            Footer: (
+                                <span>
+                                    <strong>{data.map((value) => value.proportionality).reduce(toSum)}</strong>
+                                </span>
+                            )
+                        }
+                    ]}
                     showPageSizeOptions={false}
                     ofText={"/"}
                     nextText={"→"}

--- a/src/app/Layout/Presentation/Views/SingleDistrict.tsx
+++ b/src/app/Layout/Presentation/Views/SingleDistrict.tsx
@@ -6,6 +6,7 @@ import { toSum } from "../Utilities/ReduceUtilities";
 export interface SingleDistrictProps {
     districtResults: DistrictResult[];
     districtSelected: string;
+    decimals: number;
 }
 
 export class SingleDistrict extends React.Component<SingleDistrictProps, {}> {
@@ -16,6 +17,7 @@ export class SingleDistrict extends React.Component<SingleDistrictProps, {}> {
 
     render() {
         const data = this.getData();
+        const decimals = this.props.decimals;
         return (
             <React.Fragment>
                 <h1 className="h1">{this.props.districtSelected}</h1>
@@ -81,7 +83,12 @@ export class SingleDistrict extends React.Component<SingleDistrictProps, {}> {
                             accessor: "proportionality",
                             Footer: (
                                 <span>
-                                    <strong>{data.map((value) => value.proportionality).reduce(toSum)}</strong>
+                                    <strong>
+                                        {data
+                                            .map((value) => value.proportionality)
+                                            .reduce(toSum)
+                                            .toFixed(decimals)}
+                                    </strong>
                                 </span>
                             )
                         }

--- a/src/app/Layout/PresentationSettings/PresentationSelection.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationSelection.tsx
@@ -30,7 +30,7 @@ export class PresentationSelection extends React.Component {
                 />
                 <PresentationSelectionButton
                     className="btn-block"
-                    title={"Mandatdistribusjon"}
+                    title={"Mandatfordeling"}
                     presentationSelected={PresentationType.SeatDistribution}
                 />
                 <PresentationSelectionButton


### PR DESCRIPTION
# Description
Makes various improvements on existing tables
* Navigation is now conditional on table size
* There are sums/totals in footers
* Some new utilities to make .reduce more quickly understandable
* Width of district names and party names adapted more
* Party code columns are now spaced evenly and more narrowly to reduce the necessity of scrolling
* Percentage columns removed as they are generally just duplicate data taking up space in the UI; can be better represented in a chart either way if necessary

# Testing
Make sure there aren't any major changes from the normal operation, and that the numbers are in fact correct.
## Setup
Same as normal.
## Expected
An improved series of tables!