### PR TITLE
refactor: fix bug involving .reduce function

### DIFF
--- a/src/app/Layout/Presentation/PresentationComponent.tsx
+++ b/src/app/Layout/Presentation/PresentationComponent.tsx
@@ -86,7 +86,7 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
     }
 
     getWidestStringWidth(strings: string[] = []): number {
-        return strings.map((value) => value.length).reduce(toMax)!;
+        return strings.map((value) => value.length).reduce(toMax, 0)!;
     }
 
     getLevellingSeats() {

--- a/src/app/Layout/Presentation/Views/ElectionOverview.tsx
+++ b/src/app/Layout/Presentation/Views/ElectionOverview.tsx
@@ -34,22 +34,22 @@ export class ElectionOverview extends React.Component<ElectionOverviewProps, {}>
                     {
                         Header: "Stemmer",
                         accessor: "votes",
-                        Footer: <strong>{data.map((value) => value.votes).reduce(toSum)}</strong>
+                        Footer: <strong>{data.map((value) => value.votes).reduce(toSum, 0)}</strong>
                     },
                     {
                         Header: "Distrikt",
                         accessor: "districtSeats",
-                        Footer: <strong>{data.map((value) => value.districtSeats).reduce(toSum)}</strong>
+                        Footer: <strong>{data.map((value) => value.districtSeats).reduce(toSum, 0)}</strong>
                     },
                     {
                         Header: "Utjevning",
                         accessor: "levelingSeats",
-                        Footer: <strong>{data.map((value) => value.levelingSeats).reduce(toSum)}</strong>
+                        Footer: <strong>{data.map((value) => value.levelingSeats).reduce(toSum, 0)}</strong>
                     },
                     {
                         Header: "Sum",
                         accessor: "totalSeats",
-                        Footer: <strong>{data.map((value) => value.totalSeats).reduce(toSum)}</strong>
+                        Footer: <strong>{data.map((value) => value.totalSeats).reduce(toSum, 0)}</strong>
                     },
                     {
                         Header: "Proporsjonalitet",
@@ -58,7 +58,7 @@ export class ElectionOverview extends React.Component<ElectionOverviewProps, {}>
                             <strong>
                                 {data
                                     .map((value) => value.proportionality)
-                                    .reduce(toSum)
+                                    .reduce(toSum, 0)
                                     .toFixed(this.props.decimals)}
                             </strong>
                         )


### PR DESCRIPTION
When one calls a .reduce function on an empty array, it needs to have an initial number for the sum.

It's important to check that everything runs when data is reset/cleared as well as running on initialized data.