### PR TITLE
feat: levelling seat overview

### DIFF
--- a/src/app/Layout/Presentation/PresentationComponent.tsx
+++ b/src/app/Layout/Presentation/PresentationComponent.tsx
@@ -139,13 +139,19 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
                     />
                 );
             case PresentationType.RemainderQuotients:
-                this.getLevellingSeats();
                 return (
                     <RemainderQuotients
                         districtResults={this.getSeatDistributionData()}
                         levellingSeats={this.getLevellingSeats()}
                         decimals={this.props.decimals}
                         showPartiesWithoutSeats={this.props.showPartiesWithoutSeats}
+                    />
+                );
+            case PresentationType.LevellingSeats:
+                return (
+                    <LevellingSeatOverview
+                        decimals={this.props.decimals}
+                        levellingSeatQuotients={this.getLevellingSeats()}
                     />
                 );
             default:

--- a/src/app/Layout/Presentation/PresentationComponent.tsx
+++ b/src/app/Layout/Presentation/PresentationComponent.tsx
@@ -68,13 +68,13 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
         return roundedData;
     }
 
-    getPartyCodes(): string[] {
+    getPartyCodes = (): string[] => {
         const partyCodes: string[] = [];
         this.props.results.partyResults.forEach((party) => {
             partyCodes.push(party.partyCode);
         });
         return partyCodes;
-    }
+    };
 
     getPartyNames(): string[] {
         const partyNames: string[] = [];
@@ -148,12 +148,7 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
                     />
                 );
             case PresentationType.LevellingSeats:
-                return (
-                    <LevellingSeatOverview
-                        decimals={this.props.decimals}
-                        levellingSeatQuotients={this.getLevellingSeats()}
-                    />
-                );
+                return <LevellingSeatOverview levellingSeatQuotients={this.props.results.levelingSeatDistribution} />;
             default:
                 console.log(`Could not find presentation type ${this.props.currentPresentation}`);
                 return <g />;

--- a/src/app/Layout/Presentation/PresentationComponent.tsx
+++ b/src/app/Layout/Presentation/PresentationComponent.tsx
@@ -1,7 +1,14 @@
 import * as React from "react";
 import { PresentationType } from "../Types/PresentationType";
 import { LagueDhontResult, PartyResult, DistrictResult } from "../Interfaces/Results";
-import { ElectionOverview, DistrictOverview, SeatsPerParty, SeatDistribution, SingleDistrict } from "./Views";
+import {
+    ElectionOverview,
+    DistrictOverview,
+    SeatsPerParty,
+    SeatDistribution,
+    SingleDistrict,
+    LevellingSeatOverview
+} from "./Views";
 import {
     getDistrictTableData,
     getPartyTableData,

--- a/src/app/Layout/Presentation/PresentationComponent.tsx
+++ b/src/app/Layout/Presentation/PresentationComponent.tsx
@@ -68,13 +68,13 @@ export class PresentationComponent extends React.Component<PresentationProps, {}
         return roundedData;
     }
 
-    getPartyCodes = (): string[] => {
+    getPartyCodes(): string[] {
         const partyCodes: string[] = [];
         this.props.results.partyResults.forEach((party) => {
             partyCodes.push(party.partyCode);
         });
         return partyCodes;
-    };
+    }
 
     getPartyNames(): string[] {
         const partyNames: string[] = [];

--- a/src/app/Layout/Presentation/Utilities/PresentationUtilities.ts
+++ b/src/app/Layout/Presentation/Utilities/PresentationUtilities.ts
@@ -143,6 +143,18 @@ export function flattenPartyRestQuotients(prqs: PartyRestQuotients[]): LevelingS
     return levellingSeats;
 }
 
+export function flattenAny(arr: any, result: any[] = []) {
+    for (let i = 0, length = arr.length; i < length; i++) {
+        const value = arr[i];
+        if (Array.isArray(value)) {
+            flattenAny(value, result);
+        } else {
+            result.push(value);
+        }
+    }
+    return result;
+}
+
 /**
  * Helper function that sorts seats by number.
  *

--- a/src/app/Layout/Presentation/Views/LevellingSeatOverview.tsx
+++ b/src/app/Layout/Presentation/Views/LevellingSeatOverview.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { SeatResult } from "../../Interfaces/Results";
+import { LevelingSeat } from "../../Interfaces/Results";
 import ReactTable from "react-table";
 
 interface LevellingSeatOverviewProps {
     decimals: number;
-    seatResults: SeatResult[];
+    levellingSeatQuotients: LevelingSeat[];
 }
 
 export class LevellingSeatOverview extends React.Component<LevellingSeatOverviewProps> {

--- a/src/app/Layout/Presentation/Views/LevellingSeatOverview.tsx
+++ b/src/app/Layout/Presentation/Views/LevellingSeatOverview.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { SeatResult } from "../../Interfaces/Results";
+import ReactTable from "react-table";
+
+interface LevellingSeatOverviewProps {
+    decimals: number;
+    seatResults: SeatResult[];
+}
+
+export class LevellingSeatOverview extends React.Component<LevellingSeatOverviewProps> {
+    render() {
+        return (
+            <React.Fragment>
+                <h2>Utjevningsmandater</h2>
+                <ReactTable />
+            </React.Fragment>
+        );
+    }
+}

--- a/src/app/Layout/Presentation/Views/LevellingSeatOverview.tsx
+++ b/src/app/Layout/Presentation/Views/LevellingSeatOverview.tsx
@@ -8,11 +8,19 @@ interface LevellingSeatOverviewProps {
 }
 
 export class LevellingSeatOverview extends React.Component<LevellingSeatOverviewProps> {
+    makeData() {
+        return [];
+    }
+    getColumns(data: any) {
+        return [];
+    }
     render() {
+        const data = this.makeData();
+        const columns = this.getColumns(data);
         return (
             <React.Fragment>
-                <h2>Utjevningsmandater</h2>
-                <ReactTable />
+                <h3>Utjevningsmandater</h3>
+                <ReactTable data={data} columns={columns} />
             </React.Fragment>
         );
     }

--- a/src/app/Layout/Presentation/Views/LevellingSeatOverview.tsx
+++ b/src/app/Layout/Presentation/Views/LevellingSeatOverview.tsx
@@ -1,27 +1,80 @@
 import * as React from "react";
-import { LevelingSeat } from "../../Interfaces/Results";
-import ReactTable from "react-table";
+import { PartyRestQuotients } from "../../Interfaces/Results";
+import ReactTable, { Column } from "react-table";
 
 interface LevellingSeatOverviewProps {
-    decimals: number;
-    levellingSeatQuotients: LevelingSeat[];
+    levellingSeatQuotients: PartyRestQuotients[];
+}
+
+interface LevellingSeatData {
+    partyCode: string;
+    seatsWon: string[];
 }
 
 export class LevellingSeatOverview extends React.Component<LevellingSeatOverviewProps> {
-    makeData() {
-        return [];
+    makeData(): LevellingSeatData[] {
+        const quotientsArray = this.props.levellingSeatQuotients;
+        const parties = quotientsArray.map((quotients) => {
+            return quotients.partyCode;
+        });
+        const seatData: LevellingSeatData[] = [];
+        parties.forEach((party) => {
+            seatData.push({ partyCode: party, seatsWon: [] });
+        });
+        quotientsArray.forEach((party) => {
+            const currentIndex = seatData.findIndex((data) => data.partyCode === party.partyCode);
+            party.levelingSeats.forEach((quotient) => {
+                if (quotient.seatNumber !== 0) {
+                    seatData[currentIndex].seatsWon.push(quotient.district);
+                }
+            });
+        });
+        return seatData;
     }
-    getColumns(data: any) {
-        return [];
+    getColumns() {
+        const columns: Column[] = [];
+        const data = this.makeData();
+        const mostSeatsIndex = this.findMostSeatsWon(data);
+        for (let i = 0; i < data[mostSeatsIndex].seatsWon.length; i++) {
+            // const current = data[i];
+            columns.push({
+                Header: `${i + 1}.`,
+                accessor: `seatsWon[${i}]`,
+                minWidth: 150
+            });
+        }
+
+        // Set the first column
+        columns.unshift({
+            Header: "Parti",
+            accessor: "partyCode"
+        });
+        return columns;
     }
     render() {
         const data = this.makeData();
-        const columns = this.getColumns(data);
+        const columns = this.getColumns();
         return (
             <React.Fragment>
                 <h3>Utjevningsmandater</h3>
-                <ReactTable data={data} columns={columns} />
+                <ReactTable
+                    className="-highlight -striped"
+                    data={data}
+                    columns={columns}
+                    defaultPageSize={data.length > 10 ? 10 : data.length}
+                    pageSize={data.length > 10 ? 10 : data.length}
+                    showPageSizeOptions={false}
+                    showPagination={data.length > 10 ? true : false}
+                    ofText={"/"}
+                    nextText={"→"}
+                    previousText={"←"}
+                    pageText={"#"}
+                />
             </React.Fragment>
         );
+    }
+    private findMostSeatsWon(data: LevellingSeatData[]) {
+        const seatsWon = data.map((datum) => datum.seatsWon.length);
+        return seatsWon.indexOf(Math.max(...seatsWon));
     }
 }

--- a/src/app/Layout/Presentation/Views/index.ts
+++ b/src/app/Layout/Presentation/Views/index.ts
@@ -3,3 +3,4 @@ export * from "./ElectionOverview";
 export * from "./SeatDistribution";
 export * from "./SeatsPerParty";
 export * from "./SingleDistrict";
+export * from "./LevellingSeatOverview";

--- a/src/app/Layout/PresentationSettings/PresentationSelection.tsx
+++ b/src/app/Layout/PresentationSettings/PresentationSelection.tsx
@@ -48,6 +48,11 @@ export class PresentationSelection extends React.Component {
                     title={"Restkvotienter"}
                     presentationSelected={PresentationType.RemainderQuotients}
                 />
+                <PresentationSelectionButton
+                    className="btn-block"
+                    title={"Utjevningsmandater"}
+                    presentationSelected={PresentationType.LevellingSeats}
+                />
             </React.Fragment>
         );
     }

--- a/src/app/Layout/Types/PresentationType.ts
+++ b/src/app/Layout/Types/PresentationType.ts
@@ -4,5 +4,6 @@ export enum PresentationType {
     SeatDistribution = "SEAT_DISTRIBUTION",
     SeatsPerParty = "CHART_SEATS_PER_PARTY",
     SingleCountyTable = "TABLE_SINGLE_COUNTY",
-    RemainderQuotients = "TABLE_REMAINDER_QUOTIENTS"
+    RemainderQuotients = "TABLE_REMAINDER_QUOTIENTS",
+    LevellingSeats = "TABLE_LEVELLING_SEATS_OVERVIEW"
 }


### PR DESCRIPTION
# Description
Adds a new view displaying parties with levelling seats and the order of which they received them. Closes #29

# Testing
Set it up and run it as usual, make sure to test various settings and look for errors/incongruences. Test it without deleting cache first and then delete cache and try again to ensure everything works as it's supposed to.
## Setup
Make sure you remember to run yarn before starting it.
## Expected
A new fancy view! Hooray!