### PR TITLE
docs: move pull request template so it is default

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,3 +7,5 @@ Optional description of what needs to be tested and why.
 How to test this. Add anything that deviates from the standard setup.
 ## Expected
 The expected result of your testing.
+## Issues closed
+Put a "closes #issuereferencenumber" on each line for each issue you think it closes.


### PR DESCRIPTION
The original version requires some URL hocus pocus, this seems unnecessary as the general gist of all pull requests are the same here.