### PR TITLE
Feature: disproportionality indexes

### DIFF
--- a/src/Layout/Presentation/ConnectedPresentation.tsx
+++ b/src/Layout/Presentation/ConnectedPresentation.tsx
@@ -9,7 +9,8 @@ const mapStateToProps = (state: RootState): PresentationProps => {
         currentPresentation: state.presentationMenuState.currentPresentation,
         decimals: state.presentationMenuState.decimalsNumber,
         showPartiesWithoutSeats: state.presentationMenuState.showPartiesWithoutSeats,
-        districtSelected: state.presentationMenuState.districtSelected
+        districtSelected: state.presentationMenuState.districtSelected,
+        disproportionalityIndex: state.presentationMenuState.disproportionalityIndex
     };
 };
 

--- a/src/Layout/Presentation/ElectionOverview/ElectionOverview.tsx
+++ b/src/Layout/Presentation/ElectionOverview/ElectionOverview.tsx
@@ -1,4 +1,4 @@
-﻿import * as React from "react";
+import * as React from "react";
 import ReactTable from "react-table";
 import { PartyResult } from "../../../computation";
 import { toSum } from "../../../utilities/reduce";
@@ -12,6 +12,7 @@ export interface ElectionOverviewProps {
 export class ElectionOverview extends React.Component<ElectionOverviewProps, {}> {
     render() {
         const data = this.props.partyResults;
+        const loosemoreHanbyIndex = data.map((value) => Math.abs(value.proportionality)).reduce(toSum, 0) / 2;
         return (
             <ReactTable
                 className="-highlight -striped"
@@ -54,14 +55,7 @@ export class ElectionOverview extends React.Component<ElectionOverviewProps, {}>
                     {
                         Header: "Proporsjonalitet",
                         accessor: "proportionality",
-                        Footer: (
-                            <strong>
-                                {data
-                                    .map((value) => value.proportionality)
-                                    .reduce(toSum, 0)
-                                    .toFixed(this.props.decimals)}
-                            </strong>
-                        )
+                        Footer: <strong>LHI: {loosemoreHanbyIndex.toFixed(this.props.decimals)}</strong>
                     }
                 ]}
                 defaultSorted={[

--- a/src/Layout/Presentation/ElectionOverview/ElectionOverview.tsx
+++ b/src/Layout/Presentation/ElectionOverview/ElectionOverview.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+﻿import * as React from "react";
 import ReactTable from "react-table";
 import { PartyResult } from "../../../computation";
 import { toSum } from "../../../utilities/reduce";
@@ -29,7 +29,7 @@ export class ElectionOverview extends React.Component<ElectionOverviewProps, {}>
                     {
                         Header: "Parti",
                         accessor: "partyName",
-                        width: this.props.partyNameWidth * 8,
+                        width: this.props.partyNameWidth + 165,
                         Footer: <strong>Utvalg</strong>
                     },
                     {

--- a/src/Layout/Presentation/ElectionOverview/ElectionOverview.tsx
+++ b/src/Layout/Presentation/ElectionOverview/ElectionOverview.tsx
@@ -2,17 +2,38 @@
 import ReactTable from "react-table";
 import { PartyResult } from "../../../computation";
 import { toSum } from "../../../utilities/reduce";
+import { DisproportionalityIndex } from "../presentation-models";
 
 export interface ElectionOverviewProps {
     partyResults: PartyResult[];
     decimals: number;
     partyNameWidth: number;
+    disproportionalityIndex: DisproportionalityIndex;
 }
 
 export class ElectionOverview extends React.Component<ElectionOverviewProps, {}> {
     render() {
         const data = this.props.partyResults;
-        const loosemoreHanbyIndex = data.map((value) => Math.abs(value.proportionality)).reduce(toSum, 0) / 2;
+        const proportionalities = data.map((value) => value.proportionality);
+        let index: number;
+        let label: string;
+        switch (this.props.disproportionalityIndex) {
+            case DisproportionalityIndex.LOOSEMORE_HANBY: {
+                label = "LHI";
+                index = proportionalities.map((value) => Math.abs(value)).reduce(toSum, 0) / 2;
+                break;
+            }
+            case DisproportionalityIndex.GALLAGHER: {
+                label = "GI";
+                index = Math.sqrt(proportionalities.map((value) => value * value).reduce(toSum, 0) / 2);
+                break;
+            }
+            default: {
+                label = "Error";
+                index = -1;
+            }
+        }
+
         return (
             <ReactTable
                 className="-highlight -striped"
@@ -55,7 +76,11 @@ export class ElectionOverview extends React.Component<ElectionOverviewProps, {}>
                     {
                         Header: "Proporsjonalitet",
                         accessor: "proportionality",
-                        Footer: <strong>LHI: {loosemoreHanbyIndex.toFixed(this.props.decimals)}</strong>
+                        Footer: (
+                            <strong>
+                                {label}: {index.toFixed(this.props.decimals)}
+                            </strong>
+                        )
                     }
                 ]}
                 defaultSorted={[

--- a/src/Layout/Presentation/Presentation.tsx
+++ b/src/Layout/Presentation/Presentation.tsx
@@ -21,7 +21,7 @@ import {
 import { RemainderQuotients } from "./RemainderQuotients/RemainderQuotients";
 import { toMax } from "../../utilities/reduce";
 import { LagueDhontResult, PartyResult, DistrictResult } from "../../computation";
-import { PresentationType } from "./presentation-models";
+import { PresentationType, DisproportionalityIndex } from "./presentation-models";
 
 export interface PresentationProps {
     currentPresentation: PresentationType;
@@ -29,6 +29,7 @@ export interface PresentationProps {
     decimals: number;
     showPartiesWithoutSeats: boolean;
     results: LagueDhontResult;
+    disproportionalityIndex: DisproportionalityIndex;
 }
 
 export class Presentation extends React.Component<PresentationProps, {}> {
@@ -111,6 +112,7 @@ export class Presentation extends React.Component<PresentationProps, {}> {
                         partyResults={this.getPartyTableData()}
                         decimals={this.props.decimals}
                         partyNameWidth={this.getWidestStringWidth(this.getPartyNames())}
+                        disproportionalityIndex={this.props.disproportionalityIndex}
                     />
                 );
             case PresentationType.DistrictTable:
@@ -136,6 +138,7 @@ export class Presentation extends React.Component<PresentationProps, {}> {
                         districtSelected={this.props.districtSelected}
                         districtResults={this.getSingleDistrictData()}
                         decimals={this.props.decimals}
+                        disproportionalityIndex={this.props.disproportionalityIndex}
                     />
                 );
             case PresentationType.RemainderQuotients:

--- a/src/Layout/Presentation/Presentation.tsx
+++ b/src/Layout/Presentation/Presentation.tsx
@@ -130,7 +130,7 @@ export class Presentation extends React.Component<PresentationProps, {}> {
                 );
             case PresentationType.SeatsPerParty:
                 return <SeatsPerParty partyResults={this.getSeatsPerPartyData()} />;
-            case PresentationType.SingleCountyTable:
+            case PresentationType.SingleDistrict:
                 return (
                     <SingleDistrict
                         districtSelected={this.props.districtSelected}

--- a/src/Layout/Presentation/SingleDistrict/SingleDistrict.tsx
+++ b/src/Layout/Presentation/SingleDistrict/SingleDistrict.tsx
@@ -2,11 +2,13 @@ import * as React from "react";
 import ReactTable from "react-table";
 import { DistrictResult, PartyResult } from "../../../computation/computation-models";
 import { toSum } from "../../../utilities/reduce";
+import { DisproportionalityIndex } from "../presentation-models";
 
 export interface SingleDistrictProps {
     districtResults: DistrictResult[];
     districtSelected: string;
     decimals: number;
+    disproportionalityIndex: DisproportionalityIndex;
 }
 
 export class SingleDistrict extends React.Component<SingleDistrictProps, {}> {
@@ -18,6 +20,25 @@ export class SingleDistrict extends React.Component<SingleDistrictProps, {}> {
     render() {
         const data = this.getData();
         const decimals = this.props.decimals;
+        const proportionalities = data.map((value) => value.proportionality);
+        let label: string;
+        let index: number;
+        switch (this.props.disproportionalityIndex) {
+            case DisproportionalityIndex.LOOSEMORE_HANBY: {
+                label = "LHI";
+                index = proportionalities.map((value) => Math.abs(value)).reduce(toSum, 0) / 2;
+                break;
+            }
+            case DisproportionalityIndex.GALLAGHER: {
+                label = "GI";
+                index = Math.sqrt(proportionalities.map((value) => value * value).reduce(toSum, 0) / 2);
+                break;
+            }
+            default: {
+                label = "Error";
+                index = -1;
+            }
+        }
         return (
             <React.Fragment>
                 <h1 className="h1">{this.props.districtSelected}</h1>
@@ -84,10 +105,7 @@ export class SingleDistrict extends React.Component<SingleDistrictProps, {}> {
                             Footer: (
                                 <span>
                                     <strong>
-                                        {data
-                                            .map((value) => value.proportionality)
-                                            .reduce(toSum)
-                                            .toFixed(decimals)}
+                                        {label}: {index.toFixed(decimals)}
                                     </strong>
                                 </span>
                             )

--- a/src/Layout/Presentation/presentation-models.ts
+++ b/src/Layout/Presentation/presentation-models.ts
@@ -3,7 +3,7 @@ export enum PresentationType {
     ElectionTable = "TABLE_ELECTION_OVERVIEW",
     SeatDistribution = "SEAT_DISTRIBUTION",
     SeatsPerParty = "CHART_SEATS_PER_PARTY",
-    SingleCountyTable = "TABLE_SINGLE_COUNTY",
+    SingleDistrict = "TABLE_SINGLE_COUNTY",
     RemainderQuotients = "TABLE_REMAINDER_QUOTIENTS",
     LevellingSeats = "TABLE_LEVELLING_SEATS_OVERVIEW"
 }

--- a/src/Layout/Presentation/presentation-models.ts
+++ b/src/Layout/Presentation/presentation-models.ts
@@ -7,3 +7,8 @@ export enum PresentationType {
     RemainderQuotients = "TABLE_REMAINDER_QUOTIENTS",
     LevellingSeats = "TABLE_LEVELLING_SEATS_OVERVIEW"
 }
+
+export enum DisproportionalityIndex {
+    LOOSEMORE_HANBY = "LOOSEMORE_HANBY_INDEX",
+    GALLAGHER = "GALLAGHER_INDEX"
+}

--- a/src/Layout/PresentationMenu/PresentationSelection/PresentationSelection.tsx
+++ b/src/Layout/PresentationMenu/PresentationSelection/PresentationSelection.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+﻿import * as React from "react";
 import { PresentationType } from "../../Presentation/presentation-models";
 import { ConnectedPresentationSelectionButton } from ".";
 

--- a/src/Layout/PresentationMenu/PresentationSelection/PresentationSelection.tsx
+++ b/src/Layout/PresentationMenu/PresentationSelection/PresentationSelection.tsx
@@ -1,4 +1,4 @@
-﻿import * as React from "react";
+import * as React from "react";
 import { PresentationType } from "../../Presentation/presentation-models";
 import { ConnectedPresentationSelectionButton } from ".";
 
@@ -41,7 +41,7 @@ export class PresentationSelection extends React.Component {
                 <ConnectedPresentationSelectionButton
                     className="btn-block"
                     title={"Fylkestabeller"}
-                    presentationSelected={PresentationType.SingleCountyTable}
+                    presentationSelected={PresentationType.SingleDistrict}
                 />
                 <ConnectedPresentationSelectionButton
                     className="btn-block"

--- a/src/Layout/PresentationMenu/PresentationSettings/ConnectedPresentationSettings.tsx
+++ b/src/Layout/PresentationMenu/PresentationSettings/ConnectedPresentationSettings.tsx
@@ -5,8 +5,10 @@ import {
     ChangeDecimalsAction,
     selectDistrict,
     ChangeShowPartiesNoSeats,
-    PresentationMenuAction
+    PresentationMenuAction,
+    ChangeDisproportionalityIndexAction
 } from "../presentation-menu-actions";
+import { DisproportionalityIndex } from "../../Presentation/presentation-models";
 
 function mapStateToProps(state: RootState): Partial<PresentationSettingsProps> {
     return {
@@ -14,7 +16,8 @@ function mapStateToProps(state: RootState): Partial<PresentationSettingsProps> {
         decimals: state.presentationMenuState.decimals,
         results: state.computationState.results,
         showPartiesWithoutSeats: state.presentationMenuState.showPartiesWithoutSeats,
-        districtSelected: state.presentationMenuState.districtSelected
+        districtSelected: state.presentationMenuState.districtSelected,
+        disproportionalityIndex: state.presentationMenuState.disproportionalityIndex
     };
 }
 
@@ -36,6 +39,15 @@ const mapDispatchToProps = (dispatch: any): Partial<PresentationSettingsProps> =
     },
     selectDistrict: (event: React.ChangeEvent<HTMLSelectElement>) => {
         const action = selectDistrict(event.target.value);
+        dispatch(action);
+    },
+    changeDisproportionalityIndex: (event: React.ChangeEvent<HTMLSelectElement>) => {
+        console.log("test");
+
+        const action: ChangeDisproportionalityIndexAction = {
+            type: PresentationMenuAction.ChangeDisproportionalityIndex,
+            index: event.target.value as DisproportionalityIndex
+        };
         dispatch(action);
     }
 });

--- a/src/Layout/PresentationMenu/PresentationSettings/PresentationSettings.tsx
+++ b/src/Layout/PresentationMenu/PresentationSettings/PresentationSettings.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
+﻿import * as React from "react";
 import { LagueDhontResult } from "../../../computation";
 import { SmartNumericInput } from "../../../common";
-import { PresentationType } from "../../Presentation/presentation-models";
+import { PresentationType, DisproportionalityIndex } from "../../Presentation/presentation-models";
 
 export interface PresentationSettingsProps {
     currentPresentation: PresentationType;
@@ -13,6 +13,8 @@ export interface PresentationSettingsProps {
     toggleShowPartiesWithoutSeats: (event: React.ChangeEvent<HTMLInputElement>) => void;
     selectDistrict: (event: React.ChangeEvent<HTMLSelectElement>) => void;
     results: LagueDhontResult;
+    changeDisproportionalityIndex: (event: React.ChangeEvent<HTMLSelectElement>) => void;
+    disproportionalityIndex: DisproportionalityIndex;
 }
 export class PresentationSettingsMenu extends React.Component<PresentationSettingsProps> {
     /**
@@ -29,6 +31,17 @@ export class PresentationSettingsMenu extends React.Component<PresentationSettin
             return true;
         }
         return false;
+    }
+
+    /**
+     * Helper function that checks whether the current component should
+     * show disproportionality index as an option
+     */
+    showsDisproportionality(): boolean {
+        return (
+            this.props.currentPresentation === PresentationType.SingleDistrict ||
+            this.props.currentPresentation === PresentationType.ElectionTable
+        );
     }
 
     /**
@@ -98,6 +111,25 @@ export class PresentationSettingsMenu extends React.Component<PresentationSettin
                                 })}
                             </select>
                         </div>
+                    </div>
+                    <div hidden={!this.showsDisproportionality()} className="form-group">
+                        <label htmlFor="disproportionality">Disproporsjonalitetsindeks</label>
+                        <select
+                            id="disproportionality"
+                            onChange={this.props.changeDisproportionalityIndex}
+                            className="form-control"
+                            value={this.props.disproportionalityIndex}
+                        >
+                            <option
+                                key={DisproportionalityIndex.LOOSEMORE_HANBY}
+                                value={DisproportionalityIndex.LOOSEMORE_HANBY}
+                            >
+                                Loosemore-Hanby
+                            </option>
+                            <option key={DisproportionalityIndex.GALLAGHER} value={DisproportionalityIndex.GALLAGHER}>
+                                Gallagher
+                            </option>
+                        </select>
                     </div>
                 </form>
             </React.Fragment>

--- a/src/Layout/PresentationMenu/PresentationSettings/PresentationSettings.tsx
+++ b/src/Layout/PresentationMenu/PresentationSettings/PresentationSettings.tsx
@@ -1,4 +1,4 @@
-﻿import * as React from "react";
+import * as React from "react";
 import { LagueDhontResult } from "../../../computation";
 import { SmartNumericInput } from "../../../common";
 import { PresentationType } from "../../Presentation/presentation-models";
@@ -23,7 +23,7 @@ export class PresentationSettingsMenu extends React.Component<PresentationSettin
         if (
             this.props.currentPresentation === PresentationType.DistrictTable ||
             this.props.currentPresentation === PresentationType.ElectionTable ||
-            this.props.currentPresentation === PresentationType.SingleCountyTable ||
+            this.props.currentPresentation === PresentationType.SingleDistrict ||
             this.props.currentPresentation === PresentationType.RemainderQuotients
         ) {
             return true;
@@ -39,7 +39,7 @@ export class PresentationSettingsMenu extends React.Component<PresentationSettin
      * @memberof PresentationSettings
      */
     needsDistrictDropdown(): boolean {
-        if (this.props.currentPresentation === PresentationType.SingleCountyTable) {
+        if (this.props.currentPresentation === PresentationType.SingleDistrict) {
             return true;
         }
         return false;

--- a/src/Layout/PresentationMenu/presentation-menu-actions.ts
+++ b/src/Layout/PresentationMenu/presentation-menu-actions.ts
@@ -1,11 +1,12 @@
-﻿import { PresentationType } from "../Presentation/presentation-models";
+﻿import { PresentationType, DisproportionalityIndex } from "../Presentation/presentation-models";
 
 export enum PresentationMenuAction {
     InitializePresentation = "INITIALIZE_PRESENTATION",
     ChangePresentation = "CHANGE_PRESENTATION",
     ChangeDecimals = "CHANGE_DECIMALS",
     ShowPartiesNoSeats = "SHOW_PARTIES_WITH_NO_SEATS",
-    SelectDistrict = "SELECT_DISTRICT"
+    SelectDistrict = "SELECT_DISTRICT",
+    ChangeDisproportionalityIndex = "CHANGE_DISPROPORTIONALITY_INDEX"
 }
 
 export interface ChangePresentationAction {
@@ -34,6 +35,11 @@ export interface SelectDistrictAction {
     districtSelected: string;
 }
 
+export interface ChangeDisproportionalityIndexAction {
+    type: PresentationMenuAction.ChangeDisproportionalityIndex;
+    index: DisproportionalityIndex;
+}
+
 export function initializePresentation(): InitializePresentationAction {
     const action: InitializePresentationAction = {
         type: PresentationMenuAction.InitializePresentation,
@@ -57,6 +63,14 @@ export function selectDistrict(name: string): SelectDistrictAction {
     const action: SelectDistrictAction = {
         type: PresentationMenuAction.SelectDistrict,
         districtSelected: name
+    };
+    console.log(`Action of type ${action.type} created`);
+    return action;
+}
+export function changeDisproportionalityIndex(index: DisproportionalityIndex) {
+    const action: ChangeDisproportionalityIndexAction = {
+        type: PresentationMenuAction.ChangeDisproportionalityIndex,
+        index
     };
     console.log(`Action of type ${action.type} created`);
     return action;

--- a/src/Layout/PresentationMenu/presentation-menu-reducer.ts
+++ b/src/Layout/PresentationMenu/presentation-menu-reducer.ts
@@ -5,7 +5,8 @@ import {
     ChangePresentationAction,
     ChangeDecimalsAction,
     ChangeShowPartiesNoSeats,
-    SelectDistrictAction
+    SelectDistrictAction,
+    ChangeDisproportionalityIndexAction
 } from "./presentation-menu-actions";
 
 type KnownAction =
@@ -13,7 +14,8 @@ type KnownAction =
     | ChangePresentationAction
     | ChangeDecimalsAction
     | ChangeShowPartiesNoSeats
-    | SelectDistrictAction;
+    | SelectDistrictAction
+    | ChangeDisproportionalityIndexAction;
 
 export function presentationMenuReducer(
     state: PresentationMenuState | undefined,
@@ -57,6 +59,12 @@ export function presentationMenuReducer(
             return {
                 ...state,
                 districtSelected: action.districtSelected
+            };
+        case PresentationMenuAction.ChangeDisproportionalityIndex:
+            console.log(`Action of type ${action.type} reduced`);
+            return {
+                ...state,
+                disproportionalityIndex: action.index
             };
         default:
             console.log(`Action of type ${action!.type} reduced to default`);

--- a/src/Layout/PresentationMenu/presentation-menu-state.ts
+++ b/src/Layout/PresentationMenu/presentation-menu-state.ts
@@ -1,4 +1,4 @@
-import { PresentationType } from "../Presentation/presentation-models";
+import { PresentationType, DisproportionalityIndex } from "../Presentation/presentation-models";
 
 export interface PresentationMenuState {
     currentPresentation: PresentationType;
@@ -6,6 +6,7 @@ export interface PresentationMenuState {
     decimals: string;
     decimalsNumber: number;
     showPartiesWithoutSeats: boolean;
+    disproportionalityIndex: DisproportionalityIndex;
 }
 
 export const unloadedState: PresentationMenuState = {
@@ -13,5 +14,6 @@ export const unloadedState: PresentationMenuState = {
     decimals: "2",
     decimalsNumber: 2,
     showPartiesWithoutSeats: false,
-    districtSelected: "Østfold"
+    districtSelected: "Østfold",
+    disproportionalityIndex: DisproportionalityIndex.LOOSEMORE_HANBY
 };


### PR DESCRIPTION
# Description
This pull request adds the feature of disproportionality indexes, specifically the Gallagher and Loosemore-Hanby indexes. A select element on the views affected (ElectionOverview and SingleDistrict) allows the user to choose the index, which is displayed in the footer of the Proportionality column in the affected views.

# Testing
The disproportionality results have to be compared with Celius to ensure calculations are at least reasonably sound (with the same degree of rounding). The user-interface has to be checked for potential bugs.

## Setup
Due to adding new state it is recommended to reset the application data prior to testing. 

The proportionality results have to be compared to Celius. This might prove difficult given that Celius in many places "selects" 10 of the largest parties for display, whereas Lavinia operates under a "seats/no seats" selection.
## Expected
The proportionality indices added should have equivalent values to those in Celius.
The user interface should have no bugs upon switching views or selecting different options.
## Issues closed
closes #42 
closes #43