### PR TITLE
Fix: directs the client to use lavinia-api instead of mandater

### DIFF
--- a/src/Layout/ConnectedLayout.tsx
+++ b/src/Layout/ConnectedLayout.tsx
@@ -9,7 +9,7 @@ import { initializePresentation } from "./PresentationMenu";
 
 const mapDispatchToProps = (dispatch: any): LayoutProps => ({
     initializeState: async () => {
-        const uri = "https://mandater-testing.azurewebsites.net/api/v1.0.0/no/pe?deep=true";
+        const uri = "https://lavinia-api-staging.azurewebsites.net/api/v1.0.0/no/pe?deep=true";
         const failover: ElectionType = {
             internationalName: "UNDEFINED",
             electionTypeId: -1,


### PR DESCRIPTION
# Description
Small change the api endpoint used by the client from the old mandater, to the new lavinia-api endpoint.
This allows the client to utilise the new API updates and newly added data.

# Testing
Load the website with an empty cache to ensure data is correctly downloaded from the new endpoint.

## Setup
Small change, no additional steps required.

## Expected
The client should show elections back to 1945. It should also be able to retrieve the historical settings for these years.
