### PR TITLE
Fixed incorrect results on year change

### DIFF
--- a/src/Layout/ComputationMenu/ComputationMenu.tsx
+++ b/src/Layout/ComputationMenu/ComputationMenu.tsx
@@ -65,6 +65,9 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                 {
                     ...this.props.computationPayload,
                     election,
+                    metrics,
+                    votes,
+                    parameters,
                 },
                 this.props.settingsPayload.autoCompute,
                 false


### PR DESCRIPTION
# Description
Fixed the issue with the results being wrong when selecting 2009.

## Setup
Compare the results of 2009 with Celius or Valgresultat.no
## Expected
Correct results.
