### PR TITLE
Single district percent

### DIFF
--- a/src/Layout/Presentation/SingleDistrict/SingleDistrict.tsx
+++ b/src/Layout/Presentation/SingleDistrict/SingleDistrict.tsx
@@ -7,6 +7,7 @@ import { checkExhaustively } from "../../../utilities";
 import { getVulnerableSeatByQuotient, getVulnerableSeatByVotes } from "../../../utilities/district";
 import { DistrictSelect } from "./DistrictSelect";
 import { norwegian } from "../../../utilities/rt";
+import { roundNumber } from "../../../utilities/number";
 
 export interface SingleDistrictProps {
     districtResults: DistrictResult[];
@@ -101,16 +102,8 @@ export class SingleDistrict extends React.Component<SingleDistrictProps, {}> {
                         },
                         {
                             Header: "%",
-                            accessor: "percentVotes",
-                            Footer: (
-                                <span>
-                                    <strong>
-                                        {Math.min(data.map((value) => value.percentVotes).reduce(toSum), 100).toFixed(
-                                            decimals
-                                        )}
-                                    </strong>
-                                </span>
-                            ),
+                            id: "%",
+                            accessor: (d: PartyResult) => roundNumber(d.percentVotes, decimals),
                         },
                         {
                             Header: "Mandater",

--- a/src/Layout/Presentation/SingleDistrict/SingleDistrict.tsx
+++ b/src/Layout/Presentation/SingleDistrict/SingleDistrict.tsx
@@ -100,6 +100,19 @@ export class SingleDistrict extends React.Component<SingleDistrictProps, {}> {
                             ),
                         },
                         {
+                            Header: "%",
+                            accessor: "percentVotes",
+                            Footer: (
+                                <span>
+                                    <strong>
+                                        {Math.min(data.map((value) => value.percentVotes).reduce(toSum), 100).toFixed(
+                                            decimals
+                                        )}
+                                    </strong>
+                                </span>
+                            ),
+                        },
+                        {
                             Header: "Mandater",
                             accessor: "totalSeats",
                             columns: [


### PR DESCRIPTION
# Description
Adds a column for Single District view that shows how many percent of the votes in the district each party received.

# Testing
The percentages should be visible and correct.
## Setup
Normal setup, no special configuration.
## Expected
There should be a new column in Single District that shows the percentage votes of each party,
## Issues closed
No related issue
