### PR TITLE
fix: removed duplicate of district threshold

### DIFF
--- a/src/Layout/ComputationMenu/ComputationMenu.tsx
+++ b/src/Layout/ComputationMenu/ComputationMenu.tsx
@@ -355,16 +355,6 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         integer={false}
                     />
                     <SmartNumericInput
-                        name="districtThreshold"
-                        title="Sperregrense for distriktmandat"
-                        value={this.props.settingsPayload.districtThreshold}
-                        onChange={this.onDistrictThresholdChange}
-                        min={0}
-                        max={15}
-                        defaultValue={0}
-                        integer={false}
-                    />
-                    <SmartNumericInput
                         name="levelingSeats"
                         title="Utjevningsmandater"
                         value={this.props.settingsPayload.levelingSeats}


### PR DESCRIPTION
# Description
District threshold appeared twice in the computation menu. This RP removes the duplicate.

# Testing
Ensure that the district threshold still functions as normal.
## Setup
No special setup required.
## Expected
Parties should lose seats when the district threshold is increased.
## Issues closed
closes #89 