### PR TITLE
feat: implement merging of districts

### DIFF
--- a/src/Layout/ComputationMenu/ComputationMenu.tsx
+++ b/src/Layout/ComputationMenu/ComputationMenu.tsx
@@ -10,6 +10,12 @@ import { AutoComputeCheckbox } from "./AutoComputeCheckbox";
 import { ResetButton } from "./ResetButton";
 import { ComparisonOptions } from "./ComparisonOptions";
 import { ComputeManuallyButton } from "./ComputeManuallyButton";
+import {
+    mergeElectionDistricts,
+    districtMap,
+    mergeVoteDistricts,
+    mergeMetricDistricts,
+} from "../../computation/logic/district-merging";
 
 export interface ComputationMenuProps {
     electionType: ElectionType;
@@ -32,6 +38,7 @@ export interface ComputationMenuProps {
     resetComparison: () => void;
     saveComparison: () => void;
     showComparison: boolean;
+    mergeDistricts: boolean;
 }
 
 export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
@@ -53,13 +60,19 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
      */
     onYearChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
         const nextYear = parseInt(event.target.value);
-        const election = this.props.electionType.elections.find((election) => election.year === nextYear);
-        const votes = this.props.votes.filter((vote) => vote.electionYear === nextYear);
-        const metrics = this.props.metrics.filter((metric) => metric.electionYear === nextYear);
+        let election = this.props.electionType.elections.find((election) => election.year === nextYear);
+        let votes = this.props.votes.filter((vote) => vote.electionYear === nextYear);
+        let metrics = this.props.metrics.filter((metric) => metric.electionYear === nextYear);
         const parameters =
             this.props.parameters.find((parameter) => parameter.electionYear === nextYear) || unloadedParameters;
 
         if (election !== undefined) {
+            if (nextYear >= 2005 && this.props.mergeDistricts) {
+                election = mergeElectionDistricts(election, districtMap);
+                votes = mergeVoteDistricts(votes, districtMap);
+                metrics = mergeMetricDistricts(metrics, districtMap);
+            }
+
             this.props.updateCalculation(
                 {
                     ...this.props.computationPayload,

--- a/src/Layout/ComputationMenu/ConnectedComputationMenu.tsx
+++ b/src/Layout/ComputationMenu/ConnectedComputationMenu.tsx
@@ -17,7 +17,14 @@ const mapStateToProps = (
     state: RootState
 ): Pick<
     ComputationMenuProps,
-    "computationPayload" | "settingsPayload" | "electionType" | "showComparison" | "parameters" | "metrics" | "votes"
+    | "computationPayload"
+    | "settingsPayload"
+    | "electionType"
+    | "showComparison"
+    | "parameters"
+    | "metrics"
+    | "votes"
+    | "mergeDistricts"
 > => ({
     computationPayload: {
         election: state.computationState.election,
@@ -51,6 +58,7 @@ const mapStateToProps = (
     parameters: state.requestedDataState.parameters,
     metrics: state.requestedDataState.metrics,
     votes: state.requestedDataState.votes,
+    mergeDistricts: state.presentationMenuState.mergeDistricts,
 });
 
 const mapDispatchToProps = (

--- a/src/Layout/Presentation/DistrictOverview/DistrictOverview.tsx
+++ b/src/Layout/Presentation/DistrictOverview/DistrictOverview.tsx
@@ -59,6 +59,7 @@ export class DistrictOverview extends React.Component<DistrictOverviewProps, {}>
                 <ReactTable
                     className="-highlight -striped has-text-centered"
                     defaultPageSize={this.props.districtResults.length}
+                    pageSize={this.props.districtResults.length}
                     showPaginationBottom={false}
                     data={data}
                     {...norwegian}

--- a/src/Layout/Presentation/SingleDistrict/SingleDistrict.tsx
+++ b/src/Layout/Presentation/SingleDistrict/SingleDistrict.tsx
@@ -23,12 +23,15 @@ export interface SingleDistrictProps {
 }
 
 export class SingleDistrict extends React.Component<SingleDistrictProps, {}> {
-    getDistrictResult = (name: string): DistrictResult | undefined => {
-        return this.props.districtResults.find((district) => district.name === name);
+    getDistrictResult = (name: string): DistrictResult => {
+        const selectedDistrict =
+            this.props.districtResults.find((district) => district.name === name) || this.props.districtResults[0];
+        return selectedDistrict;
     };
-    getData = (): PartyResult[] | undefined => {
+
+    getData = (): PartyResult[] => {
         const districtResult = this.getDistrictResult(this.props.districtSelected);
-        return districtResult ? districtResult.partyResults : undefined;
+        return districtResult.partyResults;
     };
 
     render() {

--- a/src/Layout/Presentation/SingleDistrict/SingleDistrict.tsx
+++ b/src/Layout/Presentation/SingleDistrict/SingleDistrict.tsx
@@ -43,8 +43,6 @@ export class SingleDistrict extends React.Component<SingleDistrictProps, {}> {
         const quotientMap = getQuotientsToVulnerableSeatMap(currentDistrictResult!);
         const vulnerable = getVulnerableSeatByQuotient(currentDistrictResult!);
         const vulnerableVotes = getVulnerableSeatByVotes(currentDistrictResult!);
-        console.log(process.env.DEBUG);
-        console.log(`Vulnerable by votes: ${vulnerableVotes.partyCode}: ${vulnerableVotes.moreVotesToWin}`);
         let label: string;
         let index: number;
         switch (this.props.disproportionalityIndex) {

--- a/src/Layout/PresentationMenu/PresentationSettings/ConnectedPresentationSettings.tsx
+++ b/src/Layout/PresentationMenu/PresentationSettings/ConnectedPresentationSettings.tsx
@@ -8,8 +8,10 @@ import {
     changeDisproportionalityIndex,
     toggleShowComparison,
     toggleShowFilters,
+    toggleMergeDistricts,
 } from "../presentation-menu-actions";
 import { DisproportionalityIndex } from "../../Presentation/presentation-models";
+import { ComputationPayload, updateComputation } from "../../../computation";
 
 /**
  * Describes which properties we want to pick from the properties of the
@@ -17,16 +19,24 @@ import { DisproportionalityIndex } from "../../Presentation/presentation-models"
  */
 interface StateProps
     extends Pick<
-            PresentationSettingsProps,
-            | "currentPresentation"
-            | "districtSelected"
-            | "decimals"
-            | "showPartiesWithoutSeats"
-            | "results"
-            | "disproportionalityIndex"
-            | "showComparison"
-            | "showFilters"
-        > {}
+        PresentationSettingsProps,
+        | "currentPresentation"
+        | "districtSelected"
+        | "decimals"
+        | "showPartiesWithoutSeats"
+        | "results"
+        | "disproportionalityIndex"
+        | "showComparison"
+        | "showFilters"
+        | "year"
+        | "mergeDistricts"
+        | "electionType"
+        | "votes"
+        | "metrics"
+        | "parameters"
+        | "computationPayload"
+        | "settingsPayload"
+    > {}
 
 function mapStateToProps(state: RootState): StateProps {
     return {
@@ -38,6 +48,39 @@ function mapStateToProps(state: RootState): StateProps {
         disproportionalityIndex: state.presentationMenuState.disproportionalityIndex,
         showComparison: state.presentationMenuState.showComparison,
         showFilters: state.presentationMenuState.showFilters,
+        year: state.computationState.election.year,
+        mergeDistricts: state.presentationMenuState.mergeDistricts,
+        electionType: state.requestedDataState.electionType,
+        votes: state.requestedDataState.votes,
+        metrics: state.requestedDataState.metrics,
+        parameters: state.computationState.parameters,
+        computationPayload: {
+            election: state.computationState.election,
+            algorithm: state.computationState.algorithm,
+            firstDivisor: state.computationState.firstDivisor,
+            electionThreshold: state.computationState.electionThreshold,
+            districtThreshold: state.computationState.districtThreshold,
+            districtSeats: state.computationState.districtSeats,
+            levelingSeats: state.computationState.levelingSeats,
+            areaFactor: state.computationState.areaFactor,
+            votes: state.computationState.votes,
+            metrics: state.computationState.metrics,
+            parameters: state.computationState.parameters,
+        },
+        settingsPayload: {
+            electionYears: state.settingsState.electionYears,
+            year: state.settingsState.year,
+            algorithm: state.settingsState.algorithm,
+            firstDivisor: state.settingsState.firstDivisor,
+            electionThreshold: state.settingsState.electionThreshold,
+            districtThreshold: state.settingsState.districtThreshold,
+            districtSeats: state.settingsState.districtSeats,
+            levelingSeats: state.settingsState.levelingSeats,
+            autoCompute: state.settingsState.autoCompute,
+            forceCompute: false,
+            areaFactor: state.settingsState.areaFactor,
+            comparison: state.settingsState.comparison,
+        },
     };
 }
 
@@ -47,14 +90,16 @@ function mapStateToProps(state: RootState): StateProps {
  */
 interface DispatchProps
     extends Pick<
-            PresentationSettingsProps,
-            | "changeDecimals"
-            | "toggleShowPartiesWithoutSeats"
-            | "selectDistrict"
-            | "changeDisproportionalityIndex"
-            | "toggleShowComparison"
-            | "toggleShowFilters"
-        > {}
+        PresentationSettingsProps,
+        | "changeDecimals"
+        | "toggleShowPartiesWithoutSeats"
+        | "selectDistrict"
+        | "changeDisproportionalityIndex"
+        | "toggleShowComparison"
+        | "toggleShowFilters"
+        | "toggleMergeDistricts"
+        | "updateCalculation"
+    > {}
 
 const mapDispatchToProps = (dispatch: any): DispatchProps => ({
     changeDecimals: (decimals: string, decimalsNumber: number) => {
@@ -80,6 +125,29 @@ const mapDispatchToProps = (dispatch: any): DispatchProps => ({
     toggleShowFilters: (event: React.ChangeEvent<HTMLInputElement>) => {
         const action = toggleShowFilters(event.target.checked);
         dispatch(action);
+    },
+    toggleMergeDistricts: (checked: boolean) => {
+        const action = toggleMergeDistricts(checked);
+        dispatch(action);
+    },
+    updateCalculation: (computationPayload: ComputationPayload, autoCompute: boolean, forceCompute: boolean) => {
+        if (autoCompute || forceCompute) {
+            const payload: ComputationPayload = {
+                election: computationPayload.election,
+                algorithm: computationPayload.algorithm,
+                firstDivisor: computationPayload.firstDivisor,
+                electionThreshold: computationPayload.electionThreshold,
+                districtThreshold: computationPayload.districtThreshold,
+                districtSeats: computationPayload.districtSeats,
+                levelingSeats: computationPayload.levelingSeats,
+                areaFactor: computationPayload.areaFactor,
+                votes: computationPayload.votes,
+                metrics: computationPayload.metrics,
+                parameters: computationPayload.parameters,
+            };
+            const updateCalculationAction = updateComputation(payload);
+            dispatch(updateCalculationAction);
+        }
     },
 });
 

--- a/src/Layout/PresentationMenu/PresentationSettings/MergeDistrictsCheckbox.tsx
+++ b/src/Layout/PresentationMenu/PresentationSettings/MergeDistrictsCheckbox.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+
+interface MergeDistrictsCheckboxProps {
+    hidden: boolean;
+    mergeDistricts: boolean;
+    toggleMergeDistricts: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export class MergeDistrictsCheckbox extends React.Component<MergeDistrictsCheckboxProps> {
+    render() {
+        return (
+            <div className="field" hidden={this.props.hidden}>
+                <label className="label" htmlFor="merge-setting">
+                    <input
+                        className="checkbox"
+                        type="checkbox"
+                        name="merge-setting"
+                        checked={this.props.mergeDistricts}
+                        onChange={this.props.toggleMergeDistricts}
+                    />
+                    &nbsp;Slå sammen 19 fylker (før 2020) til 11 fylker (etter 2020)
+                </label>
+            </div>
+        );
+    }
+}

--- a/src/Layout/PresentationMenu/presentation-menu-actions.ts
+++ b/src/Layout/PresentationMenu/presentation-menu-actions.ts
@@ -12,6 +12,7 @@ export enum PresentationMenuActionType {
     CHANGE_DISPROPORTIONALITY_INDEX = "CHANGE_DISPROPORTIONALITY_INDEX",
     TOGGLE_SHOW_COMPARISON = "TOGGLE_SHOW_COMPARISON",
     TOGGLE_SHOW_FILTERS = "TOGGLE_SHOW_FILTERS",
+    TOGGLE_MERGE_DISTRICTS = "TOGGLE_MERGE_DISTRICTS",
 }
 
 /**
@@ -25,7 +26,8 @@ export type PresentationMenuAction =
     | SelectDistrict
     | ChangeDisproportionalityIndex
     | ToggleShowComparison
-    | ToggleShowFilters;
+    | ToggleShowFilters
+    | ToggleMergeDistricts;
 
 /**
  * Action for initializing the presentation.
@@ -198,6 +200,27 @@ export function toggleShowFilters(showFilters: boolean) {
     const action: ToggleShowFilters = {
         type: PresentationMenuActionType.TOGGLE_SHOW_FILTERS,
         showFilters,
+    };
+    return action;
+}
+
+/**
+ * Action for toggling whether or not to merge districts.
+ */
+export interface ToggleMergeDistricts {
+    type: PresentationMenuActionType.TOGGLE_MERGE_DISTRICTS;
+    mergeDistricts: boolean;
+}
+
+/**
+ * Action creator for toggling whether or not to merge districts.
+ *
+ * @param mergeDistricts - true if districts should be merged, else false.
+ */
+export function toggleMergeDistricts(mergeDistricts: boolean) {
+    const action: ToggleMergeDistricts = {
+        type: PresentationMenuActionType.TOGGLE_MERGE_DISTRICTS,
+        mergeDistricts,
     };
     return action;
 }

--- a/src/Layout/PresentationMenu/presentation-menu-reducer.ts
+++ b/src/Layout/PresentationMenu/presentation-menu-reducer.ts
@@ -59,6 +59,11 @@ export function presentationMenu(
                 ...state,
                 showFilters: action.showFilters,
             };
+        case PresentationMenuActionType.TOGGLE_MERGE_DISTRICTS:
+            return {
+                ...state,
+                mergeDistricts: action.mergeDistricts,
+            };
         default:
             checkExhaustively(action);
             return state;

--- a/src/Layout/PresentationMenu/presentation-menu-state.ts
+++ b/src/Layout/PresentationMenu/presentation-menu-state.ts
@@ -3,6 +3,7 @@ import { PresentationType, DisproportionalityIndex } from "../Presentation/prese
 export interface PresentationMenuState {
     showComparison: boolean;
     showFilters: boolean;
+    mergeDistricts: boolean;
     currentPresentation: PresentationType;
     districtSelected: string;
     decimals: string;
@@ -14,6 +15,7 @@ export interface PresentationMenuState {
 export const unloadedState: PresentationMenuState = {
     showComparison: false,
     showFilters: false,
+    mergeDistricts: false,
     currentPresentation: PresentationType.ElectionTable,
     decimals: "2",
     decimalsNumber: 2,

--- a/src/computation/logic/district-merging.ts
+++ b/src/computation/logic/district-merging.ts
@@ -1,0 +1,259 @@
+import { Election, County, Result, Votes, Metrics } from "../../requested-data/requested-data-models";
+import { mapAddFromArray, mapAdd } from "../../utilities/map";
+
+export const districtMap: Map<string, string> = new Map<string, string>([
+    ["Nord-Trøndelag", "Trøndelag"],
+    ["Sør-Trøndelag", "Trøndelag"],
+    ["Hordaland", "Vestland"],
+    ["Sogn og Fjordane", "Vestland"],
+    ["Aust-Agder", "Agder"],
+    ["Vest-Agder", "Agder"],
+    ["Vestfold", "Vestfold og Telemark"],
+    ["Telemark", "Vestfold og Telemark"],
+    ["Oppland", "Innlandet"],
+    ["Hedmark", "Innlandet"],
+    ["Buskerud", "Viken"],
+    ["Akershus", "Viken"],
+    ["Østfold", "Viken"],
+    ["Troms", "Troms og Finnmark"],
+    ["Finnmark", "Troms og Finnmark"],
+]);
+
+export function mergeElectionDistricts(election: Election, districtMap: Map<string, string>): Election {
+    const { finishedDistricts, groupedDistricts, groupedResults } = groupDistrictsAndResults(
+        election.counties,
+        districtMap
+    );
+    const mergedDistricts = mergeDistrictsAndResults(groupedDistricts, groupedResults);
+    const result = finishedDistricts.concat(mergedDistricts);
+
+    return {
+        algorithm: election.algorithm,
+        counties: result,
+        countryId: election.countryId,
+        electionId: election.electionId,
+        electionTypeId: election.electionTypeId,
+        firstDivisor: election.firstDivisor,
+        levelingSeats: election.levelingSeats,
+        seats: election.seats,
+        threshold: election.threshold,
+        year: election.year,
+    };
+}
+
+function groupDistrictsAndResults(
+    districts: County[],
+    districtMap: Map<string, string>
+): {
+    finishedDistricts: County[];
+    groupedDistricts: Map<string, County[]>;
+    groupedResults: Map<string, Map<string, Result[]>>;
+} {
+    const finishedDistricts: County[] = [];
+    const groupedDistricts = new Map<string, County[]>();
+    const groupedResults = new Map<string, Map<string, Result[]>>();
+
+    for (let i = 0, n = districts.length; i < n; i++) {
+        const currentDistrict = districts[i];
+        const newName = districtMap.get(currentDistrict.name);
+
+        if (newName === undefined) {
+            finishedDistricts.push(currentDistrict);
+        } else {
+            if (!groupedResults.has(newName)) {
+                groupedResults.set(newName, new Map<string, Result[]>());
+            }
+            const results = groupedResults.get(newName);
+            if (results !== undefined) {
+                mapAddFromArray(results, getKeyFromResult, currentDistrict.results);
+                groupedResults.set(newName, results);
+            }
+            mapAdd(groupedDistricts, newName, currentDistrict);
+        }
+    }
+
+    return {
+        finishedDistricts,
+        groupedDistricts,
+        groupedResults,
+    };
+}
+
+function getKeyFromResult(result: Result): string {
+    return result.partyCode;
+}
+
+function mergeDistrictsAndResults(
+    groupedDistricts: Map<string, County[]>,
+    groupedResults: Map<string, Map<string, Result[]>>
+): County[] {
+    const finishedDistricts: County[] = [];
+
+    groupedDistricts.forEach((districtArray, districtName) => {
+        const resultMap = groupedResults.get(districtName);
+
+        if (resultMap !== undefined) {
+            const districtResults = mergeResults(resultMap, districtName);
+            const mergedDistrict = districtArray.reduce(districtReducer);
+            mergedDistrict.name = districtName;
+            mergedDistrict.results = districtResults;
+            finishedDistricts.push(mergedDistrict);
+        }
+    });
+
+    return finishedDistricts;
+}
+
+function mergeResults(resultMap: Map<string, Result[]>, districtName: string): Result[] {
+    const districtResults: Result[] = [];
+
+    resultMap.forEach((partyResults, _) => {
+        const mergedPartyResults = partyResults.reduce(resultReducer);
+        mergedPartyResults.countyName = districtName;
+        districtResults.push(mergedPartyResults);
+    });
+
+    return districtResults;
+}
+
+function resultReducer(result: Result, current: Result): Result {
+    return {
+        countyId: current.countyId,
+        countyName: "PLACEHOLDER",
+        electionId: current.electionId,
+        partyCode: current.partyCode,
+        partyId: current.partyId,
+        partyName: current.partyName,
+        percentage: result.percentage + current.percentage,
+        resultId: current.resultId,
+        votes: result.votes + current.votes,
+    };
+}
+
+function districtReducer(result: County, current: County): County {
+    return {
+        countryId: current.countryId,
+        countyId: current.countyId,
+        electionId: current.electionId,
+        name: "PLACEHOLDER",
+        results: [],
+        seats: result.seats + current.seats,
+    };
+}
+
+export function mergeVoteDistricts(votes: Votes[], districtMap: Map<string, string>): Votes[] {
+    const { finishedVotes, groupedVotes } = groupVotes(votes, districtMap);
+    const mergedVotes = mergeVotes(groupedVotes);
+    const result = finishedVotes.concat(mergedVotes);
+    console.log(result);
+
+    return result;
+}
+
+function groupVotes(
+    votes: Votes[],
+    districtMap: Map<string, string>
+): { finishedVotes: Votes[]; groupedVotes: Map<string, Map<string, Votes[]>> } {
+    const finishedVotes: Votes[] = [];
+    const groupedVotes = new Map<string, Map<string, Votes[]>>();
+
+    for (let i = 0, n = votes.length; i < n; i++) {
+        const currentVote = votes[i];
+        const newName = districtMap.get(currentVote.district);
+
+        if (newName === undefined) {
+            finishedVotes.push(currentVote);
+        } else {
+            if (!groupedVotes.has(newName)) {
+                groupedVotes.set(newName, new Map<string, Votes[]>());
+            }
+            const votes = groupedVotes.get(newName);
+            if (votes !== undefined) {
+                mapAdd(votes, currentVote.party, currentVote);
+            }
+        }
+    }
+
+    return {
+        finishedVotes,
+        groupedVotes,
+    };
+}
+
+function mergeVotes(groupedVotes: Map<string, Map<string, Votes[]>>): Votes[] {
+    const votes: Votes[] = [];
+
+    groupedVotes.forEach((districtVotes, districtName) => {
+        districtVotes.forEach((partyVotes, _) => {
+            const mergedPartyResults = partyVotes.reduce(votesReducer);
+            mergedPartyResults.district = districtName;
+            votes.push(mergedPartyResults);
+        });
+    });
+
+    return votes;
+}
+
+function votesReducer(result: Votes, current: Votes): Votes {
+    return {
+        district: "PLACEHOLDER",
+        electionType: current.electionType,
+        electionYear: current.electionYear,
+        party: current.party,
+        votes: result.votes + current.votes,
+    };
+}
+
+export function mergeMetricDistricts(metrics: Metrics[], districtMap: Map<string, string>): Metrics[] {
+    const { finishedMetrics, groupedMetrics } = groupMetrics(metrics, districtMap);
+    const mergedMetrics = mergeMetrics(groupedMetrics);
+    const result = finishedMetrics.concat(mergedMetrics);
+
+    return result;
+}
+
+function groupMetrics(
+    metrics: Metrics[],
+    districtMap: Map<string, string>
+): { finishedMetrics: Metrics[]; groupedMetrics: Map<string, Metrics[]> } {
+    const finishedMetrics: Metrics[] = [];
+    const groupedMetrics = new Map<string, Metrics[]>();
+
+    for (let i = 0, n = metrics.length; i < n; i++) {
+        const currentMetric = metrics[i];
+        const newName = districtMap.get(currentMetric.district);
+
+        if (newName === undefined) {
+            finishedMetrics.push(currentMetric);
+        } else {
+            mapAdd(groupedMetrics, newName, currentMetric);
+        }
+    }
+
+    return {
+        finishedMetrics,
+        groupedMetrics,
+    };
+}
+
+function mergeMetrics(groupedMetrics: Map<string, Metrics[]>): Metrics[] {
+    const metrics: Metrics[] = [];
+
+    groupedMetrics.forEach((districtMetrics, districtName) => {
+        const mergedMetrics = districtMetrics.reduce(metricReducer);
+        mergedMetrics.district = districtName;
+        metrics.push(mergedMetrics);
+    });
+
+    return metrics;
+}
+
+function metricReducer(result: Metrics, current: Metrics): Metrics {
+    return {
+        area: result.area + current.area,
+        district: current.district,
+        electionYear: current.electionYear,
+        population: result.population + current.population,
+        seats: result.seats + current.seats,
+    };
+}

--- a/src/computation/logic/district-merging.ts
+++ b/src/computation/logic/district-merging.ts
@@ -50,7 +50,7 @@ function groupDistrictsAndResults(
     groupedResults: Map<string, Map<string, Result[]>>;
 } {
     const finishedDistricts: County[] = [];
-    const groupedDistricts = new Map<string, County[]>();
+    let groupedDistricts = new Map<string, County[]>();
     const groupedResults = new Map<string, Map<string, Result[]>>();
 
     for (let i = 0, n = districts.length; i < n; i++) {
@@ -63,12 +63,12 @@ function groupDistrictsAndResults(
             if (!groupedResults.has(newName)) {
                 groupedResults.set(newName, new Map<string, Result[]>());
             }
-            const results = groupedResults.get(newName);
+            let results = groupedResults.get(newName);
             if (results !== undefined) {
-                mapAddFromArray(results, getKeyFromResult, currentDistrict.results);
+                results = mapAddFromArray(results, getKeyFromResult, currentDistrict.results);
                 groupedResults.set(newName, results);
             }
-            mapAdd(groupedDistricts, newName, currentDistrict);
+            groupedDistricts = mapAdd(groupedDistricts, newName, currentDistrict);
         }
     }
 
@@ -145,7 +145,6 @@ export function mergeVoteDistricts(votes: Votes[], districtMap: Map<string, stri
     const { finishedVotes, groupedVotes } = groupVotes(votes, districtMap);
     const mergedVotes = mergeVotes(groupedVotes);
     const result = finishedVotes.concat(mergedVotes);
-    console.log(result);
 
     return result;
 }
@@ -167,9 +166,9 @@ function groupVotes(
             if (!groupedVotes.has(newName)) {
                 groupedVotes.set(newName, new Map<string, Votes[]>());
             }
-            const votes = groupedVotes.get(newName);
+            let votes = groupedVotes.get(newName);
             if (votes !== undefined) {
-                mapAdd(votes, currentVote.party, currentVote);
+                votes = mapAdd(votes, currentVote.party, currentVote);
             }
         }
     }
@@ -217,7 +216,7 @@ function groupMetrics(
     districtMap: Map<string, string>
 ): { finishedMetrics: Metrics[]; groupedMetrics: Map<string, Metrics[]> } {
     const finishedMetrics: Metrics[] = [];
-    const groupedMetrics = new Map<string, Metrics[]>();
+    let groupedMetrics = new Map<string, Metrics[]>();
 
     for (let i = 0, n = metrics.length; i < n; i++) {
         const currentMetric = metrics[i];
@@ -226,7 +225,7 @@ function groupMetrics(
         if (newName === undefined) {
             finishedMetrics.push(currentMetric);
         } else {
-            mapAdd(groupedMetrics, newName, currentMetric);
+            groupedMetrics = mapAdd(groupedMetrics, newName, currentMetric);
         }
     }
 

--- a/src/utilities/map.ts
+++ b/src/utilities/map.ts
@@ -1,0 +1,33 @@
+/**
+ *
+ * Adds an element to the array associated with a key, or creates a new array if one does not exist yet.
+ *
+ * @param key The key of the value the value which will be added
+ * @param value The value that will be added to the array
+ */
+export function mapAdd<T>(map: Map<string, T[]>, key: string, value: T) {
+    if (map.has(key)) {
+        const entry = map.get(key);
+        if (entry !== undefined) {
+            entry.push(value);
+            map.set(key, entry);
+        }
+    } else {
+        map.set(key, [value]);
+    }
+}
+
+/**
+ *
+ * Adds all entries from a list to the map.
+ *
+ * @param getKey A function that returns a key from a list entry
+ * @param array A list of objects that should be added to the map
+ */
+export function mapAddFromArray<T>(map: Map<string, T[]>, getKey: (value: T) => string, array: T[]) {
+    for (let i = 0, n = array.length; i < n; i++) {
+        const entry = array[i];
+        const key = getKey(entry);
+        mapAdd(map, key, entry);
+    }
+}

--- a/src/utilities/map.ts
+++ b/src/utilities/map.ts
@@ -5,16 +5,19 @@
  * @param key The key of the value the value which will be added
  * @param value The value that will be added to the array
  */
-export function mapAdd<T>(map: Map<string, T[]>, key: string, value: T) {
+export function mapAdd<T>(map: Map<string, T[]>, key: string, value: T): Map<string, T[]> {
+    const newMap = new Map(map.entries());
     if (map.has(key)) {
         const entry = map.get(key);
         if (entry !== undefined) {
             entry.push(value);
-            map.set(key, entry);
+            newMap.set(key, entry);
         }
     } else {
-        map.set(key, [value]);
+        newMap.set(key, [value]);
     }
+
+    return newMap;
 }
 
 /**
@@ -24,10 +27,13 @@ export function mapAdd<T>(map: Map<string, T[]>, key: string, value: T) {
  * @param getKey A function that returns a key from a list entry
  * @param array A list of objects that should be added to the map
  */
-export function mapAddFromArray<T>(map: Map<string, T[]>, getKey: (value: T) => string, array: T[]) {
+export function mapAddFromArray<T>(map: Map<string, T[]>, getKey: (value: T) => string, array: T[]): Map<string, T[]> {
+    let newMap = new Map(map.entries());
     for (let i = 0, n = array.length; i < n; i++) {
         const entry = array[i];
         const key = getKey(entry);
-        mapAdd(map, key, entry);
+        newMap = mapAdd(newMap, key, entry);
     }
+
+    return newMap;
 }


### PR DESCRIPTION
# Description
Implements a checkbox that enables the user to naïvely simulate the difference between having 19 and 11 districts in an election. It combines the areas, populations, votes, etc. of the districts that were merged into the new districts.

# Testing
Test that the presentation settings still behaves as they should. This is necessary because this PR adds another column in the presentation settings, so we need to ensure all are displayed correctly.
Test that the correct districts are merged and that the final sums are correct. We want to avoid merging wrong districts and otherwise summing the numbers incorrectly.

## Setup
No special setup should be required.

## Expected
The checkbox should only be visible for elections from 2005 and later.
When the checkbox is checked, there should only be 11 districts returned in the results. The values for these districts should be the sum of the values for each of the districts that were merged.
When selecting a year earlier than 2005, all districts should be returned.

## Issues closed
closes #79 
