### PR TITLE
fix: ensure that votes is set

### DIFF
--- a/src/computation/logic/district-merging.ts
+++ b/src/computation/logic/district-merging.ts
@@ -169,6 +169,7 @@ function groupVotes(
             let votes = groupedVotes.get(newName);
             if (votes !== undefined) {
                 votes = mapAdd(votes, currentVote.party, currentVote);
+                groupedVotes.set(newName, votes!);
             }
         }
     }


### PR DESCRIPTION
# Description
Votes was not set after being updated, meaning that all changes were lost. This PR ensures that votes is being updated correctly.

closes #117 
