### PR TITLE
refactor: use AlgorithmType instead of number

### DIFF
--- a/src/Layout/ComputationMenu/AlgorithmSelect.tsx
+++ b/src/Layout/ComputationMenu/AlgorithmSelect.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
-import { getAlgorithmName } from "../../computation/logic";
+import { AlgorithmType } from "../../computation";
+import { getAlgorithmNameFromType } from "../../computation/logic";
 
 export interface AlgorithmSelectProps {
-    algorithm: number;
-    defaultAlgorithm: number;
+    algorithm: AlgorithmType;
+    defaultAlgorithm: AlgorithmType;
     onAlgorithmChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
 }
 
@@ -22,15 +23,19 @@ export class AlgorithmSelect extends React.Component<AlgorithmSelectProps> {
                             className="form-control"
                             id="algorithm_select"
                             name="calcMethod"
-                            value={this.props.algorithm.toString()}
+                            value={this.props.algorithm}
                             onChange={this.props.onAlgorithmChange}
                         >
-                            <option value="1">Sainte-Lagüe</option>
-                            <option value="2">d'Hondt</option>>
+                            <option value={AlgorithmType.SAINTE_LAGUE}>
+                                {getAlgorithmNameFromType(AlgorithmType.SAINTE_LAGUE)}
+                            </option>
+                            <option value={AlgorithmType.D_HONDT}>
+                                {getAlgorithmNameFromType(AlgorithmType.D_HONDT)}
+                            </option>
                         </select>
                     </div>
                 </div>
-                {setttingWasChanged && <label>Orginalt: {getAlgorithmName(this.props.defaultAlgorithm)}</label>}
+                {setttingWasChanged && <label>Orginalt: {getAlgorithmNameFromType(this.props.defaultAlgorithm)}</label>}
             </div>
         );
     }

--- a/src/Layout/ComputationMenu/ComputationMenu.tsx
+++ b/src/Layout/ComputationMenu/ComputationMenu.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { SmartNumericInput } from "../../common";
 import { ElectionType, Election, Votes, Metrics, Parameters } from "../../requested-data/requested-data-models";
 import { ComputationPayload, AlgorithmType, unloadedParameters } from "../../computation";
-import { getAlgorithmType } from "../../computation/logic";
 import { ComputationMenuPayload } from "./computation-menu-models";
 import { YearSelect } from "./YearSelect";
 import { AlgorithmSelect } from "./AlgorithmSelect";
@@ -106,18 +105,18 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
      * @param event a ChangeEvent whose target carries the numerified algorithm
      */
     onAlgorithmChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-        const algorithm = parseInt(event.target.value);
+        const algorithmType = event.target.value as AlgorithmType;
         this.props.updateCalculation(
             {
                 ...this.props.computationPayload,
-                algorithm: getAlgorithmType(algorithm),
+                algorithm: algorithmType,
             },
             this.props.settingsPayload.autoCompute,
             false
         );
         this.props.updateSettings({
             ...this.props.settingsPayload,
-            algorithm,
+            algorithm: algorithmType,
         });
     };
 
@@ -279,7 +278,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
             this.props.updateCalculation(
                 {
                     election,
-                    algorithm: getAlgorithmType(this.props.settingsPayload.algorithm),
+                    algorithm: this.props.settingsPayload.algorithm,
                     firstDivisor: parseFloat(this.props.settingsPayload.firstDivisor),
                     electionThreshold: parseFloat(this.props.settingsPayload.electionThreshold),
                     districtThreshold: parseFloat(this.props.settingsPayload.districtThreshold),

--- a/src/Layout/ComputationMenu/ConnectedComputationMenu.tsx
+++ b/src/Layout/ComputationMenu/ConnectedComputationMenu.tsx
@@ -10,7 +10,7 @@ import {
     saveComparison,
 } from "../../computation";
 import { Election, Votes, Metrics, Parameters } from "../../requested-data/requested-data-models";
-import { getAlgorithmTypeString } from "../../computation/logic";
+import { getAlgorithmType } from "../../computation/logic";
 import { ComputationMenuPayload } from "./computation-menu-models";
 
 const mapStateToProps = (
@@ -110,7 +110,7 @@ const mapDispatchToProps = (
         if (settingsPayload.autoCompute) {
             const payload: ComputationPayload = {
                 election,
-                algorithm: getAlgorithmTypeString(parameters.algorithm.algorithm),
+                algorithm: parameters.algorithm.algorithm,
                 firstDivisor: parameters.algorithm.parameters["First Divisor"],
                 electionThreshold: parameters.threshold,
                 districtThreshold: 0,
@@ -129,7 +129,7 @@ const mapDispatchToProps = (
 
         const newSettingsPayload: ComputationMenuPayload = {
             ...settingsPayload,
-            algorithm: election.algorithm,
+            algorithm: getAlgorithmType(election.algorithm),
             firstDivisor: election.firstDivisor.toString(),
             electionThreshold: election.threshold.toString(),
             districtThreshold: "0",

--- a/src/Layout/ComputationMenu/computation-menu-actions.ts
+++ b/src/Layout/ComputationMenu/computation-menu-actions.ts
@@ -1,5 +1,6 @@
 ﻿import { ElectionType, Parameters } from "../../requested-data/requested-data-models";
 import { ComputationMenuPayload } from "./computation-menu-models";
+import { AlgorithmType } from "../../computation";
 
 /**
  * Enum containing all possible ComputationMenuAction types.
@@ -29,7 +30,7 @@ export interface InitializeComputationMenu {
     type: ComputationMenuActionType.INITIALIZE_COMPUTATION_MENU;
     electionYears: string[];
     year: string;
-    algorithm: number;
+    algorithm: AlgorithmType;
     firstDivisor: string;
     electionThreshold: string;
     districtThreshold: string;
@@ -54,7 +55,7 @@ export function initializeComputationMenu(electionType: ElectionType, parameters
         type: ComputationMenuActionType.INITIALIZE_COMPUTATION_MENU,
         electionYears,
         year: parameters.electionYear.toString(),
-        algorithm: parameters.algorithm.id,
+        algorithm: parameters.algorithm.algorithm,
         firstDivisor: parameters.algorithm.parameters["First Divisor"].toString(),
         electionThreshold: parameters.threshold.toString(),
         districtThreshold: "0",
@@ -72,7 +73,7 @@ export function initializeComputationMenu(electionType: ElectionType, parameters
 export interface UpdateComputationMenu {
     type: ComputationMenuActionType.UPDATE_COMPUTATION_MENU;
     year: string;
-    algorithm: number;
+    algorithm: AlgorithmType;
     firstDivisor: string;
     electionThreshold: string;
     districtThreshold: string;

--- a/src/Layout/ComputationMenu/computation-menu-models.ts
+++ b/src/Layout/ComputationMenu/computation-menu-models.ts
@@ -1,7 +1,9 @@
+import { AlgorithmType } from "../../computation";
+
 export interface ComputationMenuPayload {
     electionYears: string[];
     year: string;
-    algorithm: number;
+    algorithm: AlgorithmType;
     firstDivisor: string;
     electionThreshold: string;
     districtThreshold: string;
@@ -14,7 +16,7 @@ export interface ComputationMenuPayload {
 }
 
 export interface ComputationMenuComparison {
-    algorithm: number;
+    algorithm: AlgorithmType;
     firstDivisor: string;
     electionThreshold: string;
     districtThreshold: string;

--- a/src/Layout/ComputationMenu/computation-menu-state.ts
+++ b/src/Layout/ComputationMenu/computation-menu-state.ts
@@ -1,9 +1,10 @@
 import { ComputationMenuComparison } from "./computation-menu-models";
+import { AlgorithmType } from "../../computation";
 
 export interface ComputationMenuState {
     electionYears: string[];
     year: string;
-    algorithm: number;
+    algorithm: AlgorithmType;
     firstDivisor: string;
     electionThreshold: string;
     districtThreshold: string;
@@ -17,7 +18,7 @@ export interface ComputationMenuState {
 export const unloadedState: ComputationMenuState = {
     electionYears: [],
     year: "",
-    algorithm: -1,
+    algorithm: AlgorithmType.UNDEFINED,
     firstDivisor: "",
     electionThreshold: "",
     districtThreshold: "",
@@ -26,7 +27,7 @@ export const unloadedState: ComputationMenuState = {
     autoCompute: true,
     areaFactor: "",
     comparison: {
-        algorithm: -1,
+        algorithm: AlgorithmType.UNDEFINED,
         areaFactor: "",
         districtSeats: "",
         electionThreshold: "",

--- a/src/computation/computation-state.ts
+++ b/src/computation/computation-state.ts
@@ -20,8 +20,7 @@ export interface ComputationState {
 
 export const unloadedParameters: Parameters = {
     algorithm: {
-        algorithm: "UNDEFINED",
-        id: -1,
+        algorithm: AlgorithmType.UNDEFINED,
         parameters: {},
     },
     areaFactor: -1,

--- a/src/computation/logic/algorithm-utilities.ts
+++ b/src/computation/logic/algorithm-utilities.ts
@@ -357,6 +357,22 @@ export function getAlgorithmName(type: number) {
 }
 
 /**
+ * Converts AlgorithmTypes into their matching algorithm name
+ *
+ * @param type The AlgorithmType of the algorithm
+ */
+export function getAlgorithmNameFromType(type: AlgorithmType) {
+    switch (type) {
+        case AlgorithmType.SAINTE_LAGUE:
+            return "Sainte-Lagüe";
+        case AlgorithmType.D_HONDT:
+            return "d'Hondt";
+        default:
+            return "Udefinert";
+    }
+}
+
+/**
  * Converts string IDs into their matching algorithm types
  *
  * @param type The string ID of the algorithm

--- a/src/requested-data/requested-data-models.ts
+++ b/src/requested-data/requested-data-models.ts
@@ -1,4 +1,5 @@
 import { Dictionary, RawDictionaryEntry } from "../utilities/dictionary";
+import { AlgorithmType } from "../computation";
 
 export interface County {
     countyId: number;
@@ -64,8 +65,7 @@ export interface RawAlgorithm {
 }
 
 export interface Algorithm {
-    id: number;
-    algorithm: string;
+    algorithm: AlgorithmType;
     parameters: Dictionary<number>;
 }
 

--- a/src/requested-data/requested-data-utilities.ts
+++ b/src/requested-data/requested-data-utilities.ts
@@ -1,10 +1,10 @@
 import { RawAlgorithm, Algorithm, RawParameters, Parameters } from "./requested-data-models";
 import { rawDictionaryToDictionary } from "../utilities/dictionary";
+import { getAlgorithmType } from "../computation/logic";
 
 export function rawAlgorithmToAlgorithmConverter(rawAlgorithm: RawAlgorithm): Algorithm {
     const algorithm: Algorithm = {
-        algorithm: rawAlgorithm.algorithm,
-        id: rawAlgorithm.id,
+        algorithm: getAlgorithmType(rawAlgorithm.id),
         parameters: rawDictionaryToDictionary(rawAlgorithm.parameters),
     };
 


### PR DESCRIPTION
# Description
Changes AlgorithmSelect to use AlgorithmType instead of number.

# Testing
The algorithm type should load correctly and get reset correctly when restoring historical settings as well as when saving and loading changed settings.

## Issues closed
closes #88 
