### PR TITLE
refactor: migrate to API 3.0.0

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -1,3 +1,4 @@
 API_V1=https://lavinia-api-staging.azurewebsites.net/api/v1.0.0/
 API_V2=https://lavinia-api-staging.azurewebsites.net/api/v2.0.0/
+API_V3=https://lavinia-api-staging.azurewebsites.net/api/v3.0.0/
 SWAGGERUI=https://lavinia-api-staging.azurewebsites.net/

--- a/src/Layout/ComputationMenu/ConnectedComputationMenu.tsx
+++ b/src/Layout/ComputationMenu/ConnectedComputationMenu.tsx
@@ -114,7 +114,7 @@ const mapDispatchToProps = (
                 firstDivisor: parameters.algorithm.parameters["First Divisor"],
                 electionThreshold: parameters.threshold,
                 districtThreshold: 0,
-                districtSeats: parameters.districtSeats.SUM,
+                districtSeats: parameters.districtSeats,
                 levelingSeats: parameters.levelingSeats,
                 areaFactor: parameters.areaFactor,
                 votes,

--- a/src/Layout/ComputationMenu/computation-menu-actions.ts
+++ b/src/Layout/ComputationMenu/computation-menu-actions.ts
@@ -59,7 +59,7 @@ export function initializeComputationMenu(electionType: ElectionType, parameters
         firstDivisor: parameters.algorithm.parameters["First Divisor"].toString(),
         electionThreshold: parameters.threshold.toString(),
         districtThreshold: "0",
-        districtSeats: parameters.districtSeats.SUM.toString(),
+        districtSeats: parameters.districtSeats.toString(),
         levelingSeats: parameters.levelingSeats.toString(),
         areaFactor: parameters.areaFactor.toString(),
         autoCompute: true,

--- a/src/Layout/ConnectedLayout.tsx
+++ b/src/Layout/ConnectedLayout.tsx
@@ -28,9 +28,9 @@ const mapDispatchToProps = (dispatch: any): LayoutProps => ({
 
         defaultUri = process.env.API_V1 + electionTypePath;
 
-        votesUri = process.env.API_V2 + votesPath;
-        metricsUri = process.env.API_V2 + metricsPath;
-        parametersUri = process.env.API_V2 + parametersPath;
+        votesUri = process.env.API_V3 + votesPath;
+        metricsUri = process.env.API_V3 + metricsPath;
+        parametersUri = process.env.API_V3 + parametersPath;
 
         const failover: ElectionType = {
             internationalName: "UNDEFINED",

--- a/src/computation/computation-state.ts
+++ b/src/computation/computation-state.ts
@@ -24,7 +24,7 @@ export const unloadedParameters: Parameters = {
         parameters: {},
     },
     areaFactor: -1,
-    districtSeats: {},
+    districtSeats: -1,
     electionType: "UNDEFINED",
     electionYear: -1,
     levelingSeats: -1,

--- a/src/requested-data/requested-data-models.ts
+++ b/src/requested-data/requested-data-models.ts
@@ -75,7 +75,7 @@ export interface RawParameters {
     algorithm: RawAlgorithm;
     threshold: number;
     areaFactor: number;
-    districtSeats: Array<RawDictionaryEntry>;
+    districtSeats: number;
     levelingSeats: number;
     totalVotes: number;
 }
@@ -86,7 +86,7 @@ export interface Parameters {
     algorithm: Algorithm;
     threshold: number;
     areaFactor: number;
-    districtSeats: Dictionary<number>;
+    districtSeats: number;
     levelingSeats: number;
     totalVotes: number;
 }

--- a/src/requested-data/requested-data-utilities.ts
+++ b/src/requested-data/requested-data-utilities.ts
@@ -1,10 +1,10 @@
 import { RawAlgorithm, Algorithm, RawParameters, Parameters } from "./requested-data-models";
 import { rawDictionaryToDictionary } from "../utilities/dictionary";
-import { getAlgorithmType } from "../computation/logic";
+import { getAlgorithmTypeString } from "../computation/logic";
 
 export function rawAlgorithmToAlgorithmConverter(rawAlgorithm: RawAlgorithm): Algorithm {
     const algorithm: Algorithm = {
-        algorithm: getAlgorithmType(rawAlgorithm.id),
+        algorithm: getAlgorithmTypeString(rawAlgorithm.algorithm),
         parameters: rawDictionaryToDictionary(rawAlgorithm.parameters),
     };
 
@@ -15,7 +15,7 @@ export function rawParametersToParametersConverter(rawParameters: RawParameters)
     const parameters: Parameters = {
         algorithm: rawAlgorithmToAlgorithmConverter(rawParameters.algorithm),
         areaFactor: rawParameters.areaFactor,
-        districtSeats: rawDictionaryToDictionary(rawParameters.districtSeats),
+        districtSeats: rawParameters.districtSeats,
         electionType: rawParameters.electionType,
         electionYear: rawParameters.electionYear,
         levelingSeats: rawParameters.levelingSeats,


### PR DESCRIPTION
# Description
Migrate data requests and model processing from API 2.0.0 to 3.0.0. The original pipeline from API 1.0.0 remains unchanged as it will require more substantial code restructuring.

#138 
