### PR TITLE
feat: enable use of district data from 2021

### DIFF
--- a/src/Layout/ComputationMenu/ComputationMenu.tsx
+++ b/src/Layout/ComputationMenu/ComputationMenu.tsx
@@ -38,6 +38,7 @@ export interface ComputationMenuProps {
     saveComparison: () => void;
     showComparison: boolean;
     mergeDistricts: boolean;
+    use2021Distribution: boolean;
 }
 
 export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
@@ -61,7 +62,8 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
         const nextYear = parseInt(event.target.value);
         let election = this.props.electionType.elections.find((election) => election.year === nextYear);
         let votes = this.props.votes.filter((vote) => vote.electionYear === nextYear);
-        let metrics = this.props.metrics.filter((metric) => metric.electionYear === nextYear);
+        const distributionYear = this.props.use2021Distribution && nextYear >= 2005 ? 2021 : nextYear;
+        let metrics = this.props.metrics.filter((metric) => metric.electionYear === distributionYear);
         const parameters =
             this.props.parameters.find((parameter) => parameter.electionYear === nextYear) || unloadedParameters;
 
@@ -271,7 +273,8 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
         const year = parseInt(this.props.settingsPayload.year);
         const election = this.props.electionType.elections.find((e) => e.year === year);
         const votes = this.props.votes.filter((vote) => vote.electionYear === year);
-        const metrics = this.props.metrics.filter((metric) => metric.electionYear === year);
+        const distributionYear = this.props.use2021Distribution && year >= 2005 ? 2021 : year;
+        const metrics = this.props.metrics.filter((metric) => metric.electionYear === distributionYear);
         const parameters =
             this.props.parameters.find((parameter) => parameter.electionYear === year) || unloadedParameters;
         if (election !== undefined && election !== null) {

--- a/src/Layout/ComputationMenu/ConnectedComputationMenu.tsx
+++ b/src/Layout/ComputationMenu/ConnectedComputationMenu.tsx
@@ -25,6 +25,7 @@ const mapStateToProps = (
     | "metrics"
     | "votes"
     | "mergeDistricts"
+    | "use2021Distribution"
 > => ({
     computationPayload: {
         election: state.computationState.election,
@@ -59,6 +60,7 @@ const mapStateToProps = (
     metrics: state.requestedDataState.metrics,
     votes: state.requestedDataState.votes,
     mergeDistricts: state.presentationMenuState.mergeDistricts,
+    use2021Distribution: state.presentationMenuState.use2021Distribution,
 });
 
 const mapDispatchToProps = (

--- a/src/Layout/PresentationMenu/PresentationSettings/ConnectedPresentationSettings.tsx
+++ b/src/Layout/PresentationMenu/PresentationSettings/ConnectedPresentationSettings.tsx
@@ -9,6 +9,7 @@ import {
     toggleShowComparison,
     toggleShowFilters,
     toggleMergeDistricts,
+    toggleUse2021Distribution,
 } from "../presentation-menu-actions";
 import { DisproportionalityIndex } from "../../Presentation/presentation-models";
 import { ComputationPayload, updateComputation } from "../../../computation";
@@ -30,6 +31,7 @@ interface StateProps
         | "showFilters"
         | "year"
         | "mergeDistricts"
+        | "use2021Distribution"
         | "electionType"
         | "votes"
         | "metrics"
@@ -50,6 +52,7 @@ function mapStateToProps(state: RootState): StateProps {
         showFilters: state.presentationMenuState.showFilters,
         year: state.computationState.election.year,
         mergeDistricts: state.presentationMenuState.mergeDistricts,
+        use2021Distribution: state.presentationMenuState.use2021Distribution,
         electionType: state.requestedDataState.electionType,
         votes: state.requestedDataState.votes,
         metrics: state.requestedDataState.metrics,
@@ -98,6 +101,7 @@ interface DispatchProps
         | "toggleShowComparison"
         | "toggleShowFilters"
         | "toggleMergeDistricts"
+        | "toggleUse2021Distribution"
         | "updateCalculation"
     > {}
 
@@ -128,6 +132,10 @@ const mapDispatchToProps = (dispatch: any): DispatchProps => ({
     },
     toggleMergeDistricts: (checked: boolean) => {
         const action = toggleMergeDistricts(checked);
+        dispatch(action);
+    },
+    toggleUse2021Distribution: (checked: boolean) => {
+        const action = toggleUse2021Distribution(checked);
         dispatch(action);
     },
     updateCalculation: (computationPayload: ComputationPayload, autoCompute: boolean, forceCompute: boolean) => {

--- a/src/Layout/PresentationMenu/PresentationSettings/PresentationSettings.tsx
+++ b/src/Layout/PresentationMenu/PresentationSettings/PresentationSettings.tsx
@@ -15,6 +15,7 @@ import {
     mergeMetricDistricts,
 } from "../../../computation/logic/district-merging";
 import { ComputationMenuPayload } from "../../ComputationMenu/computation-menu-models";
+import { Use2021DistributionCheckbox } from "./Use2021DistributionCheckbox";
 
 export interface PresentationSettingsProps {
     currentPresentation: PresentationType;
@@ -35,6 +36,8 @@ export interface PresentationSettingsProps {
     year: number;
     mergeDistricts: boolean;
     toggleMergeDistricts: (checked: boolean) => void;
+    use2021Distribution: boolean;
+    toggleUse2021Distribution: (checked: boolean) => void;
     electionType: ElectionType;
     votes: Votes[];
     metrics: Metrics[];
@@ -118,7 +121,8 @@ export class PresentationSettingsMenu extends React.Component<PresentationSettin
         const year = this.props.year;
         let election = this.props.electionType.elections.find((election) => election.year === year);
         let votes = this.props.votes.filter((vote) => vote.electionYear === year);
-        let metrics = this.props.metrics.filter((metric) => metric.electionYear === year);
+        const distributionYear = this.props.use2021Distribution && year >= 2005 ? 2021 : year;
+        let metrics = this.props.metrics.filter((metric) => metric.electionYear === distributionYear);
         const parameters = this.props.parameters;
 
         if (election !== undefined) {
@@ -128,6 +132,35 @@ export class PresentationSettingsMenu extends React.Component<PresentationSettin
                 metrics = mergeMetricDistricts(metrics, districtMap);
             }
 
+            this.props.updateCalculation(
+                {
+                    ...this.props.computationPayload,
+                    election,
+                    metrics,
+                    votes,
+                    parameters,
+                },
+                this.props.settingsPayload.autoCompute,
+                false
+            );
+        }
+    };
+
+    showUse2021Distribution(): boolean {
+        return this.props.year >= 2005;
+    }
+
+    onToggleUse2021Distribution = (event: React.ChangeEvent<HTMLInputElement>) => {
+        this.props.toggleUse2021Distribution(event.target.checked);
+
+        const year = this.props.year;
+        const election = this.props.electionType.elections.find((election) => election.year === year);
+        const votes = this.props.votes.filter((vote) => vote.electionYear === year);
+        const metricsYear = event.target.checked && year >= 2005 ? 2021 : year;
+        const metrics = this.props.metrics.filter((metric) => metric.electionYear === metricsYear);
+        const parameters = this.props.parameters;
+
+        if (election !== undefined) {
             this.props.updateCalculation(
                 {
                     ...this.props.computationPayload,
@@ -167,6 +200,11 @@ export class PresentationSettingsMenu extends React.Component<PresentationSettin
                             hidden={!this.showMergeDistricts()}
                             mergeDistricts={this.props.mergeDistricts}
                             toggleMergeDistricts={this.onToggleMergeDistricts}
+                        />
+                        <Use2021DistributionCheckbox
+                            hidden={!this.showUse2021Distribution()}
+                            use2021Distribution={this.props.use2021Distribution}
+                            toggleUse2021Distribution={this.onToggleUse2021Distribution}
                         />
                     </div>
                 </div>

--- a/src/Layout/PresentationMenu/PresentationSettings/Use2021DistributionCheckbox.tsx
+++ b/src/Layout/PresentationMenu/PresentationSettings/Use2021DistributionCheckbox.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+
+interface Use2021DistributionCheckboxProps {
+    hidden: boolean;
+    use2021Distribution: boolean;
+    toggleUse2021Distribution: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export class Use2021DistributionCheckbox extends React.Component<Use2021DistributionCheckboxProps> {
+    render() {
+        return (
+            <div className="field" hidden={this.props.hidden}>
+                <label className="label" htmlFor="2021-distribution-setting">
+                    <input
+                        className="checkbox"
+                        type="checkbox"
+                        name="2021-distribution-setting"
+                        checked={this.props.use2021Distribution}
+                        onChange={this.props.toggleUse2021Distribution}
+                    />
+                    &nbsp;Bruk fylkesdata fra 2021
+                </label>
+            </div>
+        );
+    }
+}

--- a/src/Layout/PresentationMenu/presentation-menu-actions.ts
+++ b/src/Layout/PresentationMenu/presentation-menu-actions.ts
@@ -13,6 +13,7 @@ export enum PresentationMenuActionType {
     TOGGLE_SHOW_COMPARISON = "TOGGLE_SHOW_COMPARISON",
     TOGGLE_SHOW_FILTERS = "TOGGLE_SHOW_FILTERS",
     TOGGLE_MERGE_DISTRICTS = "TOGGLE_MERGE_DISTRICTS",
+    TOGGLE_USE_2021_DISTRIBUTION = "TOGGLE_USE_2021_DISTRIBUTION",
 }
 
 /**
@@ -27,7 +28,8 @@ export type PresentationMenuAction =
     | ChangeDisproportionalityIndex
     | ToggleShowComparison
     | ToggleShowFilters
-    | ToggleMergeDistricts;
+    | ToggleMergeDistricts
+    | ToggleUse2021Distribution;
 
 /**
  * Action for initializing the presentation.
@@ -221,6 +223,27 @@ export function toggleMergeDistricts(mergeDistricts: boolean) {
     const action: ToggleMergeDistricts = {
         type: PresentationMenuActionType.TOGGLE_MERGE_DISTRICTS,
         mergeDistricts,
+    };
+    return action;
+}
+
+/**
+ * Action for toggling whether or not to merge districts.
+ */
+export interface ToggleUse2021Distribution {
+    type: PresentationMenuActionType.TOGGLE_USE_2021_DISTRIBUTION;
+    use2021Distribution: boolean;
+}
+
+/**
+ * Action creator for toggling whether or not to merge districts.
+ *
+ * @param mergeDistricts - true if districts should be merged, else false.
+ */
+export function toggleUse2021Distribution(use2021Distribution: boolean) {
+    const action: ToggleUse2021Distribution = {
+        type: PresentationMenuActionType.TOGGLE_USE_2021_DISTRIBUTION,
+        use2021Distribution,
     };
     return action;
 }

--- a/src/Layout/PresentationMenu/presentation-menu-reducer.ts
+++ b/src/Layout/PresentationMenu/presentation-menu-reducer.ts
@@ -64,6 +64,11 @@ export function presentationMenu(
                 ...state,
                 mergeDistricts: action.mergeDistricts,
             };
+        case PresentationMenuActionType.TOGGLE_USE_2021_DISTRIBUTION:
+            return {
+                ...state,
+                use2021Distribution: action.use2021Distribution,
+            };
         default:
             checkExhaustively(action);
             return state;

--- a/src/Layout/PresentationMenu/presentation-menu-state.ts
+++ b/src/Layout/PresentationMenu/presentation-menu-state.ts
@@ -4,6 +4,7 @@ export interface PresentationMenuState {
     showComparison: boolean;
     showFilters: boolean;
     mergeDistricts: boolean;
+    use2021Distribution: boolean;
     currentPresentation: PresentationType;
     districtSelected: string;
     decimals: string;
@@ -16,6 +17,7 @@ export const unloadedState: PresentationMenuState = {
     showComparison: false,
     showFilters: false,
     mergeDistricts: false,
+    use2021Distribution: false,
     currentPresentation: PresentationType.ElectionTable,
     decimals: "2",
     decimalsNumber: 2,

--- a/src/computation/computation-actions.ts
+++ b/src/computation/computation-actions.ts
@@ -44,10 +44,10 @@ export function initializeComputation(
     parameters: Parameters[]
 ) {
     const election: Election = electionType.elections[0]; // Most recent election
-    const filterVotes: Votes[] = votes.filter((vote) => vote.electionYear === 2017);
-    const filterMetrics: Metrics[] = metrics.filter((metric) => metric.electionYear === 2017);
+    const filterVotes: Votes[] = votes.filter((vote) => vote.electionYear === election.year);
+    const filterMetrics: Metrics[] = metrics.filter((metric) => metric.electionYear === election.year);
     const filterParameters: Parameters =
-        parameters.find((parameter) => parameter.electionYear === 2017) || unloadedParameters;
+        parameters.find((parameter) => parameter.electionYear === election.year) || unloadedParameters;
 
     const payload: ComputationPayload = {
         election,


### PR DESCRIPTION
# Description
Enables users to use district metrics from 2021 instead of the original data from the original election. This is only available for elections after 2001, as we only calculate the distribution of district seats after that election.

**Important:** This PR relies on data introduced by [Lavinia-api#31](https://github.com/Project-Lavinia/Lavinia-api/pull/31), so that PR needs to be accepted before this one.

## Setup

1. Start up a Lavinia-api instance of the branch from [Lavinia-api#31](https://github.com/Project-Lavinia/Lavinia-api/pull/31) locally on your computer
2. Configure Lavinia-client so it retrieves district metrics from the local API instance 
3. Proceed as usual

## Issues closed
closes #80 
