### PR TITLE
fix: handle few district seats

### DIFF
--- a/src/Layout/Presentation/SingleDistrict/SingleDistrict.tsx
+++ b/src/Layout/Presentation/SingleDistrict/SingleDistrict.tsx
@@ -38,8 +38,9 @@ export class SingleDistrict extends React.Component<SingleDistrictProps, {}> {
     };
 
     render() {
-        const calculateVulnerable = isQuotientAlgorithm(this.props.algorithm);
         const currentDistrictResult = this.getDistrictResult(this.props.districtSelected);
+        const calculateVulnerable =
+            isQuotientAlgorithm(this.props.algorithm) && currentDistrictResult.districtSeats > 0;
         const vulnerableMap = calculateVulnerable ? getVotesToVulnerableSeatMap(currentDistrictResult!) : undefined;
         const quotientMap = calculateVulnerable ? getQuotientsToVulnerableSeatMap(currentDistrictResult!) : undefined;
         const vulnerable = calculateVulnerable ? getVulnerableSeatByQuotient(currentDistrictResult!) : undefined;

--- a/src/computation/logic/utils.ts
+++ b/src/computation/logic/utils.ts
@@ -147,7 +147,7 @@ export function distributeDistrictSeatsOnDistricts(
 
         districtSeats = subtractLevelingSeats(districtSeats);
 
-        if (findNegativeSeats(districtSeats)) {
+        if (anyNegativeSeats(districtSeats)) {
             districtSeats = distributionByQuotient(numDistrictSeats, districtSeats, baseValues, denominatorFunction);
         }
     }
@@ -286,7 +286,7 @@ export function distributeLevelingSeatsOnDistrictsPre2005(
     return partyRestQuotients;
 }
 
-function findNegativeSeats(districtSeats: Dictionary<number>): boolean {
+function anyNegativeSeats(districtSeats: Dictionary<number>): boolean {
     for (const districtName in districtSeats) {
         if (districtSeats.hasOwnProperty(districtName)) {
             if (districtSeats[districtName] < 0) {

--- a/src/computation/logic/utils.ts
+++ b/src/computation/logic/utils.ts
@@ -120,7 +120,6 @@ export function distributeDistrictSeatsOnDistricts(
     numDistrictSeats: number,
     metrics: Metrics[]
 ): Dictionary<number> {
-    let districtSeats: Dictionary<number> = {};
     const baseValues: Dictionary<number> = {};
 
     // Wrap Sainte Lagues so it only takes one argument
@@ -130,8 +129,11 @@ export function distributeDistrictSeatsOnDistricts(
 
     if (areaFactor === -1) {
         // If we don't have an area factor, just return the predetermined values
+        const districtSeats: Dictionary<number> = {};
         metrics.forEach((metric) => (districtSeats[metric.district] = metric.seats));
+        return districtSeats;
     } else {
+        const districtSeats: Dictionary<number> = {};
         metrics.forEach((metric) => {
             // Fill districtSeats with all the districts, with no wins yet
             districtSeats[metric.district] = 0;
@@ -148,13 +150,10 @@ export function distributeDistrictSeatsOnDistricts(
 
         const districtSeatsNoLevelingSeats = subtractLevelingSeats(distributedDistrictSeatsAndLevelingSeats);
 
-        if (anyNegativeSeats(districtSeatsNoLevelingSeats)) {
-            districtSeats = distributionByQuotient(numDistrictSeats, districtSeats, baseValues, denominatorFunction);
-        } else {
-            districtSeats = districtSeatsNoLevelingSeats;
-        }
+        return anyNegativeSeats(districtSeatsNoLevelingSeats)
+            ? distributionByQuotient(numDistrictSeats, districtSeats, baseValues, denominatorFunction)
+            : districtSeatsNoLevelingSeats;
     }
-    return districtSeats;
 }
 
 /**

--- a/src/computation/logic/utils.ts
+++ b/src/computation/logic/utils.ts
@@ -139,17 +139,19 @@ export function distributeDistrictSeatsOnDistricts(
             baseValues[metric.district] = metric.population + metric.area * areaFactor;
         });
 
-        districtSeats = distributionByQuotient(
+        const distributedDistrictSeatsAndLevelingSeats = distributionByQuotient(
             numDistrictSeats + metrics.length,
             districtSeats,
             baseValues,
             denominatorFunction
         );
 
-        districtSeats = subtractLevelingSeats(districtSeats);
+        const districtSeatsNoLevelingSeats = subtractLevelingSeats(distributedDistrictSeatsAndLevelingSeats);
 
-        if (anyNegativeSeats(districtSeats)) {
+        if (anyNegativeSeats(districtSeatsNoLevelingSeats)) {
             districtSeats = distributionByQuotient(numDistrictSeats, districtSeats, baseValues, denominatorFunction);
+        } else {
+            districtSeats = districtSeatsNoLevelingSeats;
         }
     }
     return districtSeats;
@@ -287,6 +289,11 @@ export function distributeLevelingSeatsOnDistrictsPre2005(
     return partyRestQuotients;
 }
 
+/**
+ * Checks whether any districts ended up with a negative number of district seats.
+ *
+ * @param districtSeats The distribution of district seats to check
+ */
 function anyNegativeSeats(districtSeats: Dictionary<number>): boolean {
     for (const districtName in districtSeats) {
         if (districtSeats.hasOwnProperty(districtName)) {

--- a/src/computation/logic/utils.ts
+++ b/src/computation/logic/utils.ts
@@ -146,6 +146,10 @@ export function distributeDistrictSeatsOnDistricts(
         );
 
         districtSeats = subtractLevelingSeats(districtSeats);
+
+        if (findNegativeSeats(districtSeats)) {
+            districtSeats = distributionByQuotient(numDistrictSeats, districtSeats, baseValues, denominatorFunction);
+        }
     }
     return districtSeats;
 }
@@ -280,4 +284,15 @@ export function distributeLevelingSeatsOnDistrictsPre2005(
         levelingSeats.shift();
     }
     return partyRestQuotients;
+}
+
+function findNegativeSeats(districtSeats: Dictionary<number>): boolean {
+    for (const districtName in districtSeats) {
+        if (districtSeats.hasOwnProperty(districtName)) {
+            if (districtSeats[districtName] < 0) {
+                return true;
+            }
+        }
+    }
+    return false;
 }

--- a/src/utilities/district.ts
+++ b/src/utilities/district.ts
@@ -37,10 +37,12 @@ export function getQuotientsToVulnerableSeatMap(districtResult: DistrictResult):
 export function getMostVulnerableSeatByQuotient(districtResults: DistrictResult[]) {
     const vulnerableDistrictSeats: VulnerableDistrictSeat[] = [];
     districtResults.forEach((districtResult) => {
-        vulnerableDistrictSeats.push({
-            ...getVulnerableSeatByQuotient(districtResult),
-            district: districtResult.name,
-        });
+        if (districtResult.districtSeats > 0) {
+            vulnerableDistrictSeats.push({
+                ...getVulnerableSeatByQuotient(districtResult),
+                district: districtResult.name,
+            });
+        }
     });
     return vulnerableDistrictSeats.sort((a, b) => (a.moreVotesToWin >= b.moreVotesToWin ? 1 : -1))[0];
 }


### PR DESCRIPTION
# Description
Fixes the bug that occurs when attempting to distribute very few district seats on the districts.
Also fixes a bug, where the calculation of most vulnerable seat assumes that all districts have a district seat and hence crashes when some districts have 0 district seats.

closes #122 
closes #148 