### PR TITLE
add tooltip to SmartNumericInput

### DIFF
--- a/src/Layout/ComputationMenu/ComputationMenu.tsx
+++ b/src/Layout/ComputationMenu/ComputationMenu.tsx
@@ -313,7 +313,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
     render() {
         return (
             <div>
-                <h1 className="is-size-6-mobile is-size-4-tablet is-size-2-desktop is-size-1-widescreen">
+                <h1 className="is-size-6-mobile is-size-4-tablet is-size-2-desktop is-size-1-widescreen.">
                     Stortingsvalg
                 </h1>
                 <form>
@@ -345,9 +345,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         integer={false}
                         tooltip={
                             <TooltipInfo
-                                text={
-                                    "Her kan du forandre det første delingstallet i Sainte-Laguës metode. Dette er det tallet som hvert partis stemmetall deles på før tildelingen av mandater begynner."
-                                }
+                                text={"Her kan du forandre det første delingstallet i Sainte-Laguës metode."}
                             />
                         }
                     />
@@ -365,7 +363,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         tooltip={
                             <TooltipInfo
                                 text={
-                                    "Denne sperregrensen skal gjelde i det enkelte valgdistrikt, dvs. ved beregningen av distriktsmandater. I den gjeldende valgordning er det ingen slik formell sperregrense på distriktsnivå."
+                                    "For å være med i konkurransen om utjevningsmandater må partiene komme over sperregrensen (prosent av stemmene på landsbasis)."
                                 }
                             />
                         }
@@ -384,7 +382,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         tooltip={
                             <TooltipInfo
                                 text={
-                                    "Denne sperregrensen gjelder i det enkelte valgdistrikt, dvs. ved beregningen av distriktsmandater. "
+                                    "Denne sperregrensen gjelder i det enkelte valgdistrikt, dvs. ved beregningen av distriktsmandater."
                                 }
                             />
                         }
@@ -402,7 +400,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         tooltip={
                             <TooltipInfo
                                 text={
-                                    "Utjevningsmandatene går til de partiene som har kommet dårligere ut av distriktsfordelingen enn deres stemmeandel skulle tilsi. Dette bidrar til å øke proporsjonaliteten i systemet."
+                                    "Utjevningsmandatene går til de partiene som har kommet dårligere ut av distriktsfordelingen enn deres stemmeandel skulle tilsi."
                                 }
                             />
                         }
@@ -421,7 +419,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         tooltip={
                             <TooltipInfo
                                 text={
-                                    "Stortinget består av i alt 169 representanter der 150 mandater fordeles distriktsvis. I dag brukes Sainte Laguës modifiserte metode (første delingstall 1.8) til å fordele distriktsmandatene etter partienes stemmetall i de enkelte valgdistrikter."
+                                    "Stortinget består av i alt 169 representanter der 150 mandater fordeles distriktsvis."
                                 }
                             />
                         }
@@ -440,7 +438,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         tooltip={
                             <TooltipInfo
                                 text={
-                                    "Arealfaktor er tallet som multipliseres med antall kvadratkilometer i fylke før det legges til summen av antall innbyggere i fylket."
+                                    "Jo høyere arealfaktor, jo større vekt tillegges fylkets geografiske utstrekning."
                                 }
                             />
                         }

--- a/src/Layout/ComputationMenu/ComputationMenu.tsx
+++ b/src/Layout/ComputationMenu/ComputationMenu.tsx
@@ -313,7 +313,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
     render() {
         return (
             <div>
-                <h1 className="is-size-6-mobile is-size-4-tablet is-size-2-desktop is-size-1-widescreen.">
+                <h1 className="is-size-6-mobile is-size-4-tablet is-size-2-desktop is-size-1-widescreen">
                     Stortingsvalg
                 </h1>
                 <form>

--- a/src/Layout/ComputationMenu/ComputationMenu.tsx
+++ b/src/Layout/ComputationMenu/ComputationMenu.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { SmartNumericInput, SmartNumericInputWithLabel } from "../../common";
+import { SmartNumericInput, SmartNumericInputWithLabel, TooltipInfo } from "../../common";
 import { ElectionType, Election, Votes, Metrics, Parameters } from "../../requested-data/requested-data-models";
 import { ComputationPayload, AlgorithmType, unloadedParameters } from "../../computation";
 import { ComputationMenuPayload } from "./computation-menu-models";
@@ -343,6 +343,13 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         defaultValue={this.props.computationPayload.election.firstDivisor}
                         originalValue={this.props.settingsPayload.comparison.firstDivisor}
                         integer={false}
+                        tooltip={
+                            <TooltipInfo
+                                text={
+                                    "Her kan du forandre det første delingstallet i Sainte-Laguës metode. Dette er det tallet som hvert partis stemmetall deles på før tildelingen av mandater begynner."
+                                }
+                            />
+                        }
                     />
                     <SmartNumericInputWithLabel
                         name="electionThreshold"
@@ -355,6 +362,13 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         originalValue={this.props.settingsPayload.comparison.electionThreshold}
                         integer={false}
                         label={"%"}
+                        tooltip={
+                            <TooltipInfo
+                                text={
+                                    "Denne sperregrensen skal gjelde i det enkelte valgdistrikt, dvs. ved beregningen av distriktsmandater. I den gjeldende valgordning er det ingen slik formell sperregrense på distriktsnivå."
+                                }
+                            />
+                        }
                     />
                     <SmartNumericInputWithLabel
                         name="districtThreshold"
@@ -367,6 +381,13 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         originalValue={this.props.settingsPayload.comparison.districtThreshold}
                         integer={false}
                         label={"%"}
+                        tooltip={
+                            <TooltipInfo
+                                text={
+                                    "Denne sperregrensen gjelder i det enkelte valgdistrikt, dvs. ved beregningen av distriktsmandater. "
+                                }
+                            />
+                        }
                     />
                     <SmartNumericInput
                         name="levelingSeats"
@@ -378,6 +399,13 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         defaultValue={this.props.computationPayload.election.levelingSeats}
                         originalValue={this.props.settingsPayload.comparison.levelingSeats}
                         integer={true}
+                        tooltip={
+                            <TooltipInfo
+                                text={
+                                    "Utjevningsmandatene går til de partiene som har kommet dårligere ut av distriktsfordelingen enn deres stemmeandel skulle tilsi. Dette bidrar til å øke proporsjonaliteten i systemet."
+                                }
+                            />
+                        }
                     />
                     <SmartNumericInput
                         name="districtSeats"
@@ -390,6 +418,13 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         originalValue={this.props.settingsPayload.comparison.districtSeats}
                         integer={true}
                         hidden={parseInt(this.props.settingsPayload.year) < 2005}
+                        tooltip={
+                            <TooltipInfo
+                                text={
+                                    "Stortinget består av i alt 169 representanter der 150 mandater fordeles distriktsvis. I dag brukes Sainte Laguës modifiserte metode (første delingstall 1.8) til å fordele distriktsmandatene etter partienes stemmetall i de enkelte valgdistrikter."
+                                }
+                            />
+                        }
                     />
                     <SmartNumericInput
                         name="areaFactor"
@@ -402,6 +437,13 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         originalValue={this.props.settingsPayload.comparison.areaFactor}
                         integer={false}
                         hidden={parseInt(this.props.settingsPayload.year) < 2005}
+                        tooltip={
+                            <TooltipInfo
+                                text={
+                                    "Arealfaktor er tallet som multipliseres med antall kvadratkilometer i fylke før det legges til summen av antall innbyggere i fylket."
+                                }
+                            />
+                        }
                     />
                     <ComputeManuallyButton
                         autoCompute={this.props.settingsPayload.autoCompute}

--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -5,10 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <link rel="stylesheet" href="https://unpkg.com/react-table@6.10.0/react-table.css" />
         <link rel="stylesheet" href="https://unpkg.com/bulmaswatch@0.7.2/lumen/bulmaswatch.min.css" />
-        <link
-            rel="stylesheet"
-            href="https://cdn.jsdelivr.net/npm/@creativebulma/bulma-tooltip@1.1.0/dist/bulma-tooltip.min.css"
-        />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma-tooltip@3.0.2/dist/css/bulma-tooltip.min.css" />
         <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" />
         <script src="https://kit.fontawesome.com/05579d3562.js" crossorigin="anonymous"></script>
         <title>Lavinia</title>

--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -5,7 +5,12 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <link rel="stylesheet" href="https://unpkg.com/react-table@6.10.0/react-table.css" />
         <link rel="stylesheet" href="https://unpkg.com/bulmaswatch@0.7.2/lumen/bulmaswatch.min.css" />
+        <link
+            rel="stylesheet"
+            href="https://cdn.jsdelivr.net/npm/@creativebulma/bulma-tooltip@1.1.0/dist/bulma-tooltip.min.css"
+        />
         <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" />
+        <script src="https://kit.fontawesome.com/05579d3562.js" crossorigin="anonymous"></script>
         <title>Lavinia</title>
     </head>
     <body>

--- a/src/common/SmartNumericInput/SmartNumericInput.tsx
+++ b/src/common/SmartNumericInput/SmartNumericInput.tsx
@@ -13,16 +13,26 @@ export interface SmartNumericInputProps {
     slider?: boolean;
     style?: React.CSSProperties;
     hidden?: boolean;
+    tooltip?: string;
 }
 
 export class SmartNumericInput<T extends SmartNumericInputProps> extends React.Component<T, {}> {
     render() {
         const value = this.validateInput(this.props.value);
         const settingWasChanged = this.props.originalValue && this.props.originalValue !== this.props.value;
+        const tooltip = this.props.tooltip ? (
+            <span
+                className="icon has-text-info has-tooltip-multiline has-tooltip-arrow"
+                data-tooltip={this.props.tooltip}
+            >
+                {" "}
+                <i className="fas fa-info-circle" />
+            </span>
+        ) : null;
         return (
             <div hidden={this.props.hidden} className="field">
                 <label htmlFor={this.props.name} className="label">
-                    {this.props.title}
+                    {this.props.title}&nbsp;{tooltip}
                 </label>
                 <div className="control">
                     <input

--- a/src/common/SmartNumericInput/SmartNumericInput.tsx
+++ b/src/common/SmartNumericInput/SmartNumericInput.tsx
@@ -13,26 +13,17 @@ export interface SmartNumericInputProps {
     slider?: boolean;
     style?: React.CSSProperties;
     hidden?: boolean;
-    tooltip?: string;
+    tooltip?: any;
 }
 
 export class SmartNumericInput<T extends SmartNumericInputProps> extends React.Component<T, {}> {
     render() {
         const value = this.validateInput(this.props.value);
         const settingWasChanged = this.props.originalValue && this.props.originalValue !== this.props.value;
-        const tooltip = this.props.tooltip ? (
-            <span
-                className="icon has-text-info has-tooltip-multiline has-tooltip-arrow"
-                data-tooltip={this.props.tooltip}
-            >
-                {" "}
-                <i className="fas fa-info-circle" />
-            </span>
-        ) : null;
         return (
             <div hidden={this.props.hidden} className="field">
                 <label htmlFor={this.props.name} className="label">
-                    {this.props.title}&nbsp;{tooltip}
+                    {this.props.title}&nbsp;{this.props.tooltip}
                 </label>
                 <div className="control">
                     <input

--- a/src/common/SmartNumericInputWithLabel/SmartNumericInputWithLabel.tsx
+++ b/src/common/SmartNumericInputWithLabel/SmartNumericInputWithLabel.tsx
@@ -10,10 +10,19 @@ export class SmartNumericInputWithLabel extends SmartNumericInput<SmartNumericIn
         const value = this.validateInput(this.props.value);
         const settingWasChanged = this.props.originalValue && this.props.originalValue !== this.props.value;
         const label = this.props.label;
+        const tooltip = this.props.tooltip ? (
+            <span
+                className="icon has-text-info has-tooltip-multiline has-tooltip-arrow"
+                data-tooltip={this.props.tooltip}
+            >
+                {" "}
+                <i className="fas fa-info-circle" />
+            </span>
+        ) : null;
         return (
             <div hidden={this.props.hidden} className="field">
                 <label htmlFor={this.props.name} className="label">
-                    {this.props.title}
+                    {this.props.title}&nbsp;{tooltip}
                 </label>
                 <div className="control has-icons-right">
                     <input

--- a/src/common/SmartNumericInputWithLabel/SmartNumericInputWithLabel.tsx
+++ b/src/common/SmartNumericInputWithLabel/SmartNumericInputWithLabel.tsx
@@ -41,7 +41,7 @@ export class SmartNumericInputWithLabel extends SmartNumericInput<SmartNumericIn
                             max={this.props.max}
                         />
                     )}
-                    <span className="icon is-medium is-right">
+                    <span className="icon has-text-dark is-medium is-right">
                         <p>{label}</p>
                     </span>
                 </div>

--- a/src/common/SmartNumericInputWithLabel/SmartNumericInputWithLabel.tsx
+++ b/src/common/SmartNumericInputWithLabel/SmartNumericInputWithLabel.tsx
@@ -10,19 +10,10 @@ export class SmartNumericInputWithLabel extends SmartNumericInput<SmartNumericIn
         const value = this.validateInput(this.props.value);
         const settingWasChanged = this.props.originalValue && this.props.originalValue !== this.props.value;
         const label = this.props.label;
-        const tooltip = this.props.tooltip ? (
-            <span
-                className="icon has-text-info has-tooltip-multiline has-tooltip-arrow"
-                data-tooltip={this.props.tooltip}
-            >
-                {" "}
-                <i className="fas fa-info-circle" />
-            </span>
-        ) : null;
         return (
             <div hidden={this.props.hidden} className="field">
                 <label htmlFor={this.props.name} className="label">
-                    {this.props.title}&nbsp;{tooltip}
+                    {this.props.title}&nbsp;{this.props.tooltip}
                 </label>
                 <div className="control has-icons-right">
                     <input

--- a/src/common/TooltipInfo/TooltipInfo.tsx
+++ b/src/common/TooltipInfo/TooltipInfo.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+
+export interface TooltipInfoProps {
+    text: string;
+}
+
+export class TooltipInfo extends React.Component<TooltipInfoProps, {}> {
+    render() {
+        return (
+            <span className="icon has-text-info has-tooltip-multiline has-tooltip-arrow" data-tooltip={this.props.text}>
+                {" "}
+                <i className="fas fa-info-circle" />
+            </span>
+        );
+    }
+}

--- a/src/common/TooltipInfo/TooltipInfo.tsx
+++ b/src/common/TooltipInfo/TooltipInfo.tsx
@@ -7,7 +7,7 @@ export interface TooltipInfoProps {
 export class TooltipInfo extends React.Component<TooltipInfoProps, {}> {
     render() {
         return (
-            <span className="icon has-text-info has-tooltip-multiline has-tooltip-arrow" data-tooltip={this.props.text}>
+            <span className="icon has-tooltip-multiline has-tooltip-arrow" data-tooltip={this.props.text}>
                 {" "}
                 <i className="fas fa-info-circle" />
             </span>

--- a/src/common/TooltipInfo/index.ts
+++ b/src/common/TooltipInfo/index.ts
@@ -1,0 +1,1 @@
+export * from "./TooltipInfo";

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,3 +1,4 @@
 export * from "./Button/Button";
 export * from "./SmartNumericInput";
 export * from "./SmartNumericInputWithLabel";
+export * from "./TooltipInfo";


### PR DESCRIPTION

Now you can write tooltip-text for each SmartNumericInput in ComputationMenu. Visible by hovering the info-icon next to the label.