### PR TITLE
feature: hide show all parties when it is not relevant

### DIFF
--- a/src/Layout/ComputationMenu/ComputationMenu.tsx
+++ b/src/Layout/ComputationMenu/ComputationMenu.tsx
@@ -340,7 +340,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         tooltip={
                             <TooltipInfoRight
                                 text={"Her kan du velge året stortingsvalget ble holdt."}
-                                url={WIKIURL+"/#Valgt%20%C3%A5r"}
+                                url={WIKIURL + "/#Valgt%20%C3%A5r"}
                             />
                         }
                     />
@@ -351,7 +351,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         tooltip={
                             <TooltipInfo
                                 text={"Her kan du velge beregningsmetode for fordeling av mandater."}
-                                url={WIKIURL+"/#Valgt%20metode"}
+                                url={WIKIURL + "/#Valgt%20metode"}
                             />
                         }
                     />
@@ -369,7 +369,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         tooltip={
                             <TooltipInfo
                                 text={"Her kan du forandre det første delingstallet i Sainte-Laguës metode."}
-                                url={WIKIURL+"/#F%C3%B8rste%20delingstall"}
+                                url={WIKIURL + "/#F%C3%B8rste%20delingstall"}
                             />
                         }
                     />
@@ -387,13 +387,13 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         tooltip={
                             <TooltipInfo
                                 text={"Her kan du forandre sperregrensen for å få tildelt utjevningsmandat."}
-                                url={WIKIURL+"/#Sperregrense%20for%20utjevningsmandat"}
+                                url={WIKIURL + "/#Sperregrense%20for%20utjevningsmandat"}
                             />
                         }
                     />
                     <SmartNumericInputWithLabel
                         name="districtThreshold"
-                        title="Sperregrense for distriktmandat"
+                        title="Sperregrense for distriktmandater"
                         value={this.props.settingsPayload.districtThreshold}
                         onChange={this.onDistrictThresholdChange}
                         min={0}
@@ -406,7 +406,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         tooltip={
                             <TooltipInfo
                                 text={"Her kan du sette inn en sperregrense også for distriktsmandatene."}
-                                url={WIKIURL+"/#Sperregrense%20for%20distriktmandat"}
+                                url={WIKIURL + "/#Sperregrense%20for%20distriktmandat"}
                             />
                         }
                     />
@@ -423,7 +423,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         tooltip={
                             <TooltipInfo
                                 text={"Her kan du endre antall utjevningsmandater."}
-                                url={WIKIURL+"/#Utjevningsmandater"}
+                                url={WIKIURL + "/#Utjevningsmandater"}
                             />
                         }
                     />
@@ -441,7 +441,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         tooltip={
                             <TooltipInfo
                                 text={"Her kan du endre antall distriktsmandater."}
-                                url={WIKIURL+"/#Distriktsmandater"}
+                                url={WIKIURL + "/#Distriktsmandater"}
                             />
                         }
                     />
@@ -459,7 +459,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         tooltip={
                             <TooltipInfo
                                 text={"Her kan du endre balansen mellom folketall og fylkets areal."}
-                                url={WIKIURL+"/#Arealfaktor"}
+                                url={WIKIURL + "/#Arealfaktor"}
                             />
                         }
                     />

--- a/src/Layout/PresentationMenu/PresentationSettings/NoSeatsCheckbox.tsx
+++ b/src/Layout/PresentationMenu/PresentationSettings/NoSeatsCheckbox.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 export interface NoSeatsCheckboxProps {
+    hidden: boolean;
     showPartiesWithoutSeats: boolean;
     toggleShowPartiesWithoutSeats: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
@@ -8,7 +9,7 @@ export interface NoSeatsCheckboxProps {
 export class NoSeatsCheckbox extends React.Component<NoSeatsCheckboxProps> {
     render() {
         return (
-            <div className="field">
+            <div hidden={this.props.hidden} className="field">
                 <label className="checkbox" htmlFor="no-seats-setting">
                     <input
                         type="checkbox"

--- a/src/Layout/PresentationMenu/PresentationSettings/PresentationSettings.tsx
+++ b/src/Layout/PresentationMenu/PresentationSettings/PresentationSettings.tsx
@@ -107,6 +107,18 @@ export class PresentationSettingsMenu extends React.Component<PresentationSettin
         return this.props.currentPresentation === PresentationType.ElectionTable;
     }
 
+    /**
+     * Helper function for evaluating whether filters checkbox should be shown.
+     *
+     * @returns true if filters checkbox should be shown, false otherwise
+     */
+    showNoSeatsCheckbox(): boolean {
+        return (
+            this.props.currentPresentation !== PresentationType.DistrictTable &&
+            this.props.currentPresentation !== PresentationType.LevellingSeats
+        );
+    }
+
     onToggleMergeDistricts = (event: React.ChangeEvent<HTMLInputElement>) => {
         this.props.toggleMergeDistricts(event.target.checked);
 
@@ -173,6 +185,7 @@ export class PresentationSettingsMenu extends React.Component<PresentationSettin
                 <div className="columns">
                     <div className="column">
                         <NoSeatsCheckbox
+                            hidden={!this.showNoSeatsCheckbox()}
                             showPartiesWithoutSeats={this.props.showPartiesWithoutSeats}
                             toggleShowPartiesWithoutSeats={this.props.toggleShowPartiesWithoutSeats}
                         />


### PR DESCRIPTION
# Description
Hides the show all parties check box when it does not make sense for the related view.

closes #170 