### PR TITLE
fix: handle compare when year changes

### DIFF
--- a/src/Layout/Presentation/ElectionOverview/ElectionOverview.tsx
+++ b/src/Layout/Presentation/ElectionOverview/ElectionOverview.tsx
@@ -39,8 +39,9 @@ export class ElectionOverview extends React.Component<ElectionOverviewProps, {}>
         const data: ElectionOverviewDatum[] = [];
         const currents = this.props.partyResults;
         const comparisons = this.props.comparisonPartyResults;
+        const shouldCalculateDifference = currents.length === comparisons.length;
         for (let i = 0; i < currents.length; i++) {
-            const difference = currents[i].totalSeats - comparisons[i].totalSeats;
+            const difference = shouldCalculateDifference ? currents[i].totalSeats - comparisons[i].totalSeats : 0;
             const datum: ElectionOverviewDatum = {
                 ...this.props.partyResults[i],
                 totalSeatDifference: difference,
@@ -129,9 +130,11 @@ export class ElectionOverview extends React.Component<ElectionOverviewProps, {}>
                             filterMethod: caseInsensitiveFilterMethod,
                             Footer: <strong>Utvalg</strong>,
                             Cell: (row) => {
-                                return row.original.partyName
-                                    ? <abbr title={row.original.partyName}>{row.value}</abbr>
-                                    : row.value;
+                                return row.original.partyName ? (
+                                    <abbr title={row.original.partyName}>{row.value}</abbr>
+                                ) : (
+                                    row.value
+                                );
                             },
                         },
                         {


### PR DESCRIPTION
# Description
Correctly handle the case when the current number of parties does not equal the number of parties from the previous result.

Closes #184 