### PR TITLE
refactor: Migrate from API v1

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -1,4 +1,3 @@
-API_V1=https://lavinia-api-staging.azurewebsites.net/api/v1.0.0/
 API_V2=https://lavinia-api-staging.azurewebsites.net/api/v2.0.0/
 API_V3=https://lavinia-api-staging.azurewebsites.net/api/v3.0.0/
 SWAGGERUI=https://lavinia-api-staging.azurewebsites.net/

--- a/.env.defaults
+++ b/.env.defaults
@@ -1,4 +1,3 @@
-API_V2=https://lavinia-api-staging.azurewebsites.net/api/v2.0.0/
 API_V3=https://lavinia-api-staging.azurewebsites.net/api/v3.0.0/
 SWAGGERUI=https://lavinia-api-staging.azurewebsites.net/
 WIKI=https://project-lavinia.github.io/

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,6 @@
 {
     "baseUrl": "http://localhost:3000",
     "projectId": "brqtr2",
-    "video": false
+    "video": false,
+    "supportFile": "cypress/support/index.ts"
 }

--- a/src/Layout/ComputationMenu/ComputationMenu.tsx
+++ b/src/Layout/ComputationMenu/ComputationMenu.tsx
@@ -12,7 +12,6 @@ import { ComputeManuallyButton } from "./ComputeManuallyButton";
 import { districtMap, mergeVoteDistricts, mergeMetricDistricts } from "../../computation/logic/district-merging";
 import { shouldDistributeDistrictSeats } from "../../utilities/conditionals";
 import { isLargestFractionAlgorithm } from "../../computation/logic";
-import { Dictionary } from "../../utilities/dictionary";
 
 const WIKIURL = process.env.WIKI;
 
@@ -30,9 +29,14 @@ export interface ComputationMenuProps {
         votes: Votes[],
         metrics: Metrics[],
         parameters: Parameters,
-        partyMap: Dictionary<string>
+        partyMap: Map<string, string>
     ) => any;
-    resetHistorical: (votes: Votes[], metrics: Metrics[], parameters: Parameters, partyMap: Dictionary<string>) => void;
+    resetHistorical: (
+        votes: Votes[],
+        metrics: Metrics[],
+        parameters: Parameters,
+        partyMap: Map<string, string>
+    ) => void;
     resetComparison: () => void;
     saveComparison: () => void;
     showComparison: boolean;

--- a/src/Layout/ComputationMenu/ComputationMenu.tsx
+++ b/src/Layout/ComputationMenu/ComputationMenu.tsx
@@ -29,13 +29,13 @@ export interface ComputationMenuProps {
         votes: Votes[],
         metrics: Metrics[],
         parameters: Parameters,
-        partyMap: Map<string, string>
+        partyMap: _.Dictionary<string>
     ) => any;
     resetHistorical: (
         votes: Votes[],
         metrics: Metrics[],
         parameters: Parameters,
-        partyMap: Map<string, string>
+        partyMap: _.Dictionary<string>
     ) => void;
     resetComparison: () => void;
     saveComparison: () => void;

--- a/src/Layout/ComputationMenu/ComputationMenu.tsx
+++ b/src/Layout/ComputationMenu/ComputationMenu.tsx
@@ -68,7 +68,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
         const parameters =
             this.props.parameters.find((parameter) => parameter.electionYear === nextYear) || unloadedParameters;
 
-        if (parameters !== undefined) {
+        if (parameters) {
             if (shouldDistributeDistrictSeats(nextYear) && this.props.mergeDistricts) {
                 votes = mergeVoteDistricts(votes, districtMap);
                 metrics = mergeMetricDistricts(metrics, districtMap);

--- a/src/Layout/ComputationMenu/ComputationMenu.tsx
+++ b/src/Layout/ComputationMenu/ComputationMenu.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { SmartNumericInput, SmartNumericInputWithLabel, TooltipInfo, TooltipInfoRight } from "../../common";
-import { ElectionType, Election, Votes, Metrics, Parameters } from "../../requested-data/requested-data-models";
+import { Votes, Metrics, Parameters, FirstDivisor } from "../../requested-data/requested-data-models";
 import { ComputationPayload, AlgorithmType, unloadedParameters } from "../../computation";
 import { ComputationMenuPayload } from "./computation-menu-models";
 import { YearSelect } from "./YearSelect";
@@ -9,19 +9,14 @@ import { AutoComputeCheckbox } from "./AutoComputeCheckbox";
 import { ResetButton } from "./ResetButton";
 import { ComparisonOptions } from "./ComparisonOptions";
 import { ComputeManuallyButton } from "./ComputeManuallyButton";
-import {
-    mergeElectionDistricts,
-    districtMap,
-    mergeVoteDistricts,
-    mergeMetricDistricts,
-} from "../../computation/logic/district-merging";
+import { districtMap, mergeVoteDistricts, mergeMetricDistricts } from "../../computation/logic/district-merging";
 import { shouldDistributeDistrictSeats } from "../../utilities/conditionals";
 import { isLargestFractionAlgorithm } from "../../computation/logic";
+import { Dictionary } from "../../utilities/dictionary";
 
 const WIKIURL = process.env.WIKI;
 
 export interface ComputationMenuProps {
-    electionType: ElectionType;
     votes: Votes[];
     metrics: Metrics[];
     parameters: Parameters[];
@@ -32,12 +27,12 @@ export interface ComputationMenuProps {
     toggleAutoCompute: (autoCompute: boolean) => any;
     resetToHistoricalSettings: (
         settingsPayload: ComputationMenuPayload,
-        election: Election,
         votes: Votes[],
         metrics: Metrics[],
-        parameters: Parameters
+        parameters: Parameters,
+        partyMap: Dictionary<string>
     ) => any;
-    resetHistorical: (election: Election, votes: Votes[], metrics: Metrics[], parameters: Parameters) => void;
+    resetHistorical: (votes: Votes[], metrics: Metrics[], parameters: Parameters, partyMap: Dictionary<string>) => void;
     resetComparison: () => void;
     saveComparison: () => void;
     showComparison: boolean;
@@ -67,25 +62,22 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
      */
     onYearChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
         const nextYear = parseInt(event.target.value);
-        let election = this.props.electionType.elections.find((election) => election.year === nextYear);
         let votes = this.props.votes.filter((vote) => vote.electionYear === nextYear);
         const distributionYear = this.props.use2021Distribution && nextYear >= 2005 ? 2021 : nextYear;
         let metrics = this.props.metrics.filter((metric) => metric.electionYear === distributionYear);
         const parameters =
             this.props.parameters.find((parameter) => parameter.electionYear === nextYear) || unloadedParameters;
 
-        if (election !== undefined) {
+        if (parameters !== undefined) {
             if (shouldDistributeDistrictSeats(nextYear) && this.props.mergeDistricts) {
-                election = mergeElectionDistricts(election, districtMap);
                 votes = mergeVoteDistricts(votes, districtMap);
                 metrics = mergeMetricDistricts(metrics, districtMap);
             }
 
-            this.props.resetHistorical(election, votes, metrics, parameters);
+            this.props.resetHistorical(votes, metrics, parameters, this.props.computationPayload.partyMap);
             this.props.updateCalculation(
                 {
                     ...this.props.computationPayload,
-                    election,
                     metrics,
                     votes,
                     parameters,
@@ -99,10 +91,10 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                     ...this.props.settingsPayload,
                     year: event.target.value,
                 },
-                election,
                 votes,
                 metrics,
-                parameters
+                parameters,
+                this.props.computationPayload.partyMap
             );
         }
     };
@@ -278,16 +270,14 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
      */
     computeManually = () => {
         const year = parseInt(this.props.settingsPayload.year);
-        const election = this.props.electionType.elections.find((e) => e.year === year);
         const votes = this.props.votes.filter((vote) => vote.electionYear === year);
         const distributionYear = this.props.use2021Distribution && year >= 2005 ? 2021 : year;
         const metrics = this.props.metrics.filter((metric) => metric.electionYear === distributionYear);
         const parameters =
             this.props.parameters.find((parameter) => parameter.electionYear === year) || unloadedParameters;
-        if (election !== undefined && election !== null) {
+        if (parameters !== undefined) {
             this.props.updateCalculation(
                 {
-                    election,
                     algorithm: this.props.settingsPayload.algorithm,
                     firstDivisor: parseFloat(this.props.settingsPayload.firstDivisor),
                     electionThreshold: parseFloat(this.props.settingsPayload.electionThreshold),
@@ -298,6 +288,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                     votes,
                     metrics,
                     parameters,
+                    partyMap: this.props.computationPayload.partyMap,
                 },
                 this.props.settingsPayload.autoCompute,
                 true
@@ -313,10 +304,10 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
         const compPayload = this.props.computationPayload;
         this.props.resetToHistoricalSettings(
             this.props.settingsPayload,
-            compPayload.election,
             compPayload.votes,
             compPayload.metrics,
-            compPayload.parameters
+            compPayload.parameters,
+            compPayload.partyMap
         );
     };
 
@@ -380,7 +371,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         onChange={this.onFirstDivisorChange}
                         min={1}
                         max={5}
-                        defaultValue={this.props.computationPayload.election.firstDivisor}
+                        defaultValue={this.props.computationPayload.parameters.algorithm.parameters[FirstDivisor] || 0}
                         originalValue={this.props.settingsPayload.comparison.firstDivisor}
                         integer={false}
                         tooltip={
@@ -397,7 +388,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         onChange={this.onThresholdChange}
                         min={0}
                         max={15}
-                        defaultValue={this.props.computationPayload.election.threshold}
+                        defaultValue={this.props.computationPayload.parameters.threshold}
                         originalValue={this.props.settingsPayload.comparison.electionThreshold}
                         integer={false}
                         label={"%"}
@@ -434,7 +425,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         onChange={this.onLevelingSeatsChange}
                         min={0}
                         max={100}
-                        defaultValue={this.props.computationPayload.election.levelingSeats}
+                        defaultValue={this.props.computationPayload.parameters.levelingSeats}
                         originalValue={this.props.settingsPayload.comparison.levelingSeats}
                         integer={true}
                         tooltip={
@@ -451,7 +442,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
                         onChange={this.onDistrictSeatsChange}
                         min={0}
                         max={500}
-                        defaultValue={this.props.computationPayload.election.seats}
+                        defaultValue={this.props.computationPayload.parameters.districtSeats}
                         originalValue={this.props.settingsPayload.comparison.districtSeats}
                         integer={true}
                         hidden={!shouldDistributeDistrictSeats(year)}

--- a/src/Layout/ComputationMenu/ComputationMenu.tsx
+++ b/src/Layout/ComputationMenu/ComputationMenu.tsx
@@ -279,7 +279,7 @@ export class ComputationMenu extends React.Component<ComputationMenuProps, {}> {
         const metrics = this.props.metrics.filter((metric) => metric.electionYear === distributionYear);
         const parameters =
             this.props.parameters.find((parameter) => parameter.electionYear === year) || unloadedParameters;
-        if (parameters !== undefined) {
+        if (parameters) {
             this.props.updateCalculation(
                 {
                     algorithm: this.props.settingsPayload.algorithm,

--- a/src/Layout/ComputationMenu/ConnectedComputationMenu.tsx
+++ b/src/Layout/ComputationMenu/ConnectedComputationMenu.tsx
@@ -105,7 +105,7 @@ const mapDispatchToProps = (
         votes: Votes[],
         metrics: Metrics[],
         parameters: Parameters,
-        partyMap: Map<string, string>
+        partyMap: _.Dictionary<string>
     ) => {
         const firstDivisor = parameters.algorithm.parameters["First Divisor"]
             ? parameters.algorithm.parameters["First Divisor"]
@@ -152,7 +152,7 @@ const mapDispatchToProps = (
         const resetSavedSettingsAction = resetSavedSettings();
         dispatch(resetSavedSettingsAction);
     },
-    resetHistorical: (votes: Votes[], metrics: Metrics[], parameters: Parameters, partyMap: Map<string, string>) => {
+    resetHistorical: (votes: Votes[], metrics: Metrics[], parameters: Parameters, partyMap: _.Dictionary<string>) => {
         const updateHistoricalAction = updateHistorical(votes, metrics, parameters, partyMap);
         dispatch(updateHistoricalAction);
     },

--- a/src/Layout/ComputationMenu/ConnectedComputationMenu.tsx
+++ b/src/Layout/ComputationMenu/ConnectedComputationMenu.tsx
@@ -12,7 +12,6 @@ import {
 } from "../../computation";
 import { Votes, Metrics, Parameters } from "../../requested-data/requested-data-models";
 import { ComputationMenuPayload } from "./computation-menu-models";
-import { Dictionary } from "../../utilities/dictionary";
 
 const mapStateToProps = (
     state: RootState
@@ -106,7 +105,7 @@ const mapDispatchToProps = (
         votes: Votes[],
         metrics: Metrics[],
         parameters: Parameters,
-        partyMap: Dictionary<string>
+        partyMap: Map<string, string>
     ) => {
         const firstDivisor = parameters.algorithm.parameters["First Divisor"]
             ? parameters.algorithm.parameters["First Divisor"]
@@ -153,7 +152,7 @@ const mapDispatchToProps = (
         const resetSavedSettingsAction = resetSavedSettings();
         dispatch(resetSavedSettingsAction);
     },
-    resetHistorical: (votes: Votes[], metrics: Metrics[], parameters: Parameters, partyMap: Dictionary<string>) => {
+    resetHistorical: (votes: Votes[], metrics: Metrics[], parameters: Parameters, partyMap: Map<string, string>) => {
         const updateHistoricalAction = updateHistorical(votes, metrics, parameters, partyMap);
         dispatch(updateHistoricalAction);
     },

--- a/src/Layout/ComputationMenu/ConnectedComputationMenu.tsx
+++ b/src/Layout/ComputationMenu/ConnectedComputationMenu.tsx
@@ -10,9 +10,9 @@ import {
     saveComparison,
     computationDefaults,
 } from "../../computation";
-import { Election, Votes, Metrics, Parameters } from "../../requested-data/requested-data-models";
-import { getAlgorithmType } from "../../computation/logic";
+import { Votes, Metrics, Parameters } from "../../requested-data/requested-data-models";
 import { ComputationMenuPayload } from "./computation-menu-models";
+import { Dictionary } from "../../utilities/dictionary";
 
 const mapStateToProps = (
     state: RootState
@@ -20,7 +20,6 @@ const mapStateToProps = (
     ComputationMenuProps,
     | "computationPayload"
     | "settingsPayload"
-    | "electionType"
     | "showComparison"
     | "parameters"
     | "metrics"
@@ -29,7 +28,6 @@ const mapStateToProps = (
     | "use2021Distribution"
 > => ({
     computationPayload: {
-        election: state.computationState.election,
         algorithm: state.computationState.algorithm,
         firstDivisor: state.computationState.firstDivisor,
         electionThreshold: state.computationState.electionThreshold,
@@ -40,6 +38,7 @@ const mapStateToProps = (
         votes: state.computationState.votes,
         metrics: state.computationState.metrics,
         parameters: state.computationState.parameters,
+        partyMap: state.requestedDataState.partyMap,
     },
     settingsPayload: {
         electionYears: state.settingsState.electionYears,
@@ -55,7 +54,6 @@ const mapStateToProps = (
         areaFactor: state.settingsState.areaFactor,
         comparison: state.settingsState.comparison,
     },
-    electionType: state.requestedDataState.electionType,
     showComparison: state.presentationMenuState.showComparison,
     parameters: state.requestedDataState.parameters,
     metrics: state.requestedDataState.metrics,
@@ -79,7 +77,6 @@ const mapDispatchToProps = (
     updateCalculation: (computationPayload: ComputationPayload, autoCompute: boolean, forceCompute: boolean) => {
         if (autoCompute || forceCompute) {
             const payload: ComputationPayload = {
-                election: computationPayload.election,
                 algorithm: computationPayload.algorithm,
                 firstDivisor: computationPayload.firstDivisor,
                 electionThreshold: computationPayload.electionThreshold,
@@ -90,6 +87,7 @@ const mapDispatchToProps = (
                 votes: computationPayload.votes,
                 metrics: computationPayload.metrics,
                 parameters: computationPayload.parameters,
+                partyMap: computationPayload.partyMap,
             };
             const updateCalculationAction = updateComputation(payload);
             dispatch(updateCalculationAction);
@@ -105,10 +103,10 @@ const mapDispatchToProps = (
     },
     resetToHistoricalSettings: (
         settingsPayload: ComputationMenuPayload,
-        election: Election,
         votes: Votes[],
         metrics: Metrics[],
-        parameters: Parameters
+        parameters: Parameters,
+        partyMap: Dictionary<string>
     ) => {
         const firstDivisor = parameters.algorithm.parameters["First Divisor"]
             ? parameters.algorithm.parameters["First Divisor"]
@@ -116,7 +114,6 @@ const mapDispatchToProps = (
 
         if (settingsPayload.autoCompute) {
             const payload: ComputationPayload = {
-                election,
                 algorithm: parameters.algorithm.algorithm,
                 firstDivisor,
                 electionThreshold: parameters.threshold,
@@ -127,8 +124,9 @@ const mapDispatchToProps = (
                 votes,
                 metrics,
                 parameters,
+                partyMap,
             };
-            const updateHistoricalAction = updateHistorical(election, votes, metrics, parameters);
+            const updateHistoricalAction = updateHistorical(votes, metrics, parameters, partyMap);
             dispatch(updateHistoricalAction);
             const updateCalculationAction = updateComputation(payload);
             dispatch(updateCalculationAction);
@@ -136,12 +134,12 @@ const mapDispatchToProps = (
 
         const newSettingsPayload: ComputationMenuPayload = {
             ...settingsPayload,
-            algorithm: getAlgorithmType(election.algorithm),
+            algorithm: parameters.algorithm.algorithm,
             firstDivisor: firstDivisor.toString(),
-            electionThreshold: election.threshold.toString(),
+            electionThreshold: parameters.threshold.toString(),
             districtThreshold: "0",
-            districtSeats: election.seats.toString(),
-            levelingSeats: election.levelingSeats.toString(),
+            districtSeats: parameters.districtSeats.toString(),
+            levelingSeats: parameters.levelingSeats.toString(),
             areaFactor: parameters.areaFactor.toString(),
         };
         const updateSettingsAction = updateComputationMenu(newSettingsPayload);
@@ -155,8 +153,8 @@ const mapDispatchToProps = (
         const resetSavedSettingsAction = resetSavedSettings();
         dispatch(resetSavedSettingsAction);
     },
-    resetHistorical: (election: Election, votes: Votes[], metrics: Metrics[], parameters: Parameters) => {
-        const updateHistoricalAction = updateHistorical(election, votes, metrics, parameters);
+    resetHistorical: (votes: Votes[], metrics: Metrics[], parameters: Parameters, partyMap: Dictionary<string>) => {
+        const updateHistoricalAction = updateHistorical(votes, metrics, parameters, partyMap);
         dispatch(updateHistoricalAction);
     },
     saveComparison: () => {

--- a/src/Layout/ComputationMenu/computation-menu-actions.ts
+++ b/src/Layout/ComputationMenu/computation-menu-actions.ts
@@ -1,4 +1,4 @@
-﻿import { ElectionType, Parameters } from "../../requested-data/requested-data-models";
+﻿import { Parameters, FirstDivisor } from "../../requested-data/requested-data-models";
 import { ComputationMenuPayload } from "./computation-menu-models";
 import { AlgorithmType } from "../../computation";
 
@@ -45,18 +45,13 @@ export interface InitializeComputationMenu {
  *
  * @param electionType - election data fetched from the API.
  */
-export function initializeComputationMenu(electionType: ElectionType, parameters: Parameters) {
-    const electionYears: string[] = [];
-    for (const currentElection of electionType.elections) {
-        electionYears.push(currentElection.year.toString());
-    }
-
+export function initializeComputationMenu(electionYears: string[], parameters: Parameters) {
     const action: InitializeComputationMenu = {
         type: ComputationMenuActionType.INITIALIZE_COMPUTATION_MENU,
         electionYears,
         year: parameters.electionYear.toString(),
         algorithm: parameters.algorithm.algorithm,
-        firstDivisor: parameters.algorithm.parameters["First Divisor"].toString(),
+        firstDivisor: parameters.algorithm.parameters[FirstDivisor].toString(),
         electionThreshold: parameters.threshold.toString(),
         districtThreshold: "0",
         districtSeats: parameters.districtSeats.toString(),

--- a/src/Layout/ConnectedLayout.tsx
+++ b/src/Layout/ConnectedLayout.tsx
@@ -14,7 +14,6 @@ import { initializePresentation } from "./PresentationMenu";
 import { stateIsInvalid } from "../store/version";
 import { rawParametersToParametersConverter } from "../requested-data/requested-data-utilities";
 import { RootState } from "../reducers";
-import { createMapFromObject } from "../utilities/map";
 
 const mapStateToProps = (state: RootState): Pick<LayoutProps, "dataLoaded"> => ({
     dataLoaded: state.requestedDataState.dataLoaded,
@@ -42,8 +41,7 @@ const mapDispatchToProps = (dispatch: any): Pick<LayoutProps, "initializeState">
             const initializeRequestedParametersAction = initializeRequestedParameters(parameters);
             dispatch(initializeRequestedParametersAction);
 
-            const partyMapObject = await request<{ [name: string]: string }>(partyMapUri, {});
-            const partyMap = createMapFromObject(partyMapObject);
+            const partyMap = await request<_.Dictionary<string>>(partyMapUri, {});
             const initializeRequestedPartyMapAction = initializeRequestedPartyMap(partyMap);
             dispatch(initializeRequestedPartyMapAction);
 

--- a/src/Layout/ConnectedLayout.tsx
+++ b/src/Layout/ConnectedLayout.tsx
@@ -14,7 +14,6 @@ import { initializePresentation } from "./PresentationMenu";
 import { stateIsInvalid } from "../store/version";
 import { rawParametersToParametersConverter } from "../requested-data/requested-data-utilities";
 import { RootState } from "../reducers";
-import { Dictionary } from "../utilities/dictionary";
 
 const mapStateToProps = (state: RootState): Pick<LayoutProps, "dataLoaded"> => ({
     dataLoaded: state.requestedDataState.dataLoaded,
@@ -42,7 +41,7 @@ const mapDispatchToProps = (dispatch: any): Pick<LayoutProps, "initializeState">
             const initializeRequestedParametersAction = initializeRequestedParameters(parameters);
             dispatch(initializeRequestedParametersAction);
 
-            const partyMap = await request<Dictionary<string>>(partyMapUri, {});
+            const partyMap = await request<Map<string, string>>(partyMapUri, new Map<string, string>());
             const initializeRequestedPartyMapAction = initializeRequestedPartyMap(partyMap);
             dispatch(initializeRequestedPartyMapAction);
 

--- a/src/Layout/ConnectedLayout.tsx
+++ b/src/Layout/ConnectedLayout.tsx
@@ -14,6 +14,7 @@ import { initializePresentation } from "./PresentationMenu";
 import { stateIsInvalid } from "../store/version";
 import { rawParametersToParametersConverter } from "../requested-data/requested-data-utilities";
 import { RootState } from "../reducers";
+import { createMapFromObject } from "../utilities/map";
 
 const mapStateToProps = (state: RootState): Pick<LayoutProps, "dataLoaded"> => ({
     dataLoaded: state.requestedDataState.dataLoaded,
@@ -41,7 +42,8 @@ const mapDispatchToProps = (dispatch: any): Pick<LayoutProps, "initializeState">
             const initializeRequestedParametersAction = initializeRequestedParameters(parameters);
             dispatch(initializeRequestedParametersAction);
 
-            const partyMap = await request<Map<string, string>>(partyMapUri, new Map<string, string>());
+            const partyMapObject = await request<{ [name: string]: string }>(partyMapUri, {});
+            const partyMap = createMapFromObject(partyMapObject);
             const initializeRequestedPartyMapAction = initializeRequestedPartyMap(partyMap);
             dispatch(initializeRequestedPartyMapAction);
 

--- a/src/Layout/Presentation/presentation-utilities.ts
+++ b/src/Layout/Presentation/presentation-utilities.ts
@@ -1,5 +1,4 @@
 import { PartyResult, DistrictResult, LevelingSeat, PartyRestQuotients } from "../../computation";
-import { Dictionary } from "../../utilities/dictionary";
 import { roundNumber } from "../../utilities/number";
 
 export function getPartyTableData(
@@ -59,7 +58,7 @@ export function getSeatDistributionData(
     if (showPartiesWithoutSeats) {
         return districtResults;
     } else {
-        const partySeats: Dictionary<number> = {};
+        const partySeats: _.Dictionary<number> = {};
         const newDistrictResults: DistrictResult[] = [];
 
         for (const party of partyResults) {

--- a/src/Layout/PresentationMenu/PresentationSettings/ConnectedPresentationSettings.tsx
+++ b/src/Layout/PresentationMenu/PresentationSettings/ConnectedPresentationSettings.tsx
@@ -32,7 +32,6 @@ interface StateProps
         | "year"
         | "mergeDistricts"
         | "use2021Distribution"
-        | "electionType"
         | "votes"
         | "metrics"
         | "parameters"
@@ -50,15 +49,13 @@ function mapStateToProps(state: RootState): StateProps {
         disproportionalityIndex: state.presentationMenuState.disproportionalityIndex,
         showComparison: state.presentationMenuState.showComparison,
         showFilters: state.presentationMenuState.showFilters,
-        year: state.computationState.election.year,
+        year: state.computationState.parameters.electionYear,
         mergeDistricts: state.presentationMenuState.mergeDistricts,
         use2021Distribution: state.presentationMenuState.use2021Distribution,
-        electionType: state.requestedDataState.electionType,
         votes: state.requestedDataState.votes,
         metrics: state.requestedDataState.metrics,
         parameters: state.computationState.parameters,
         computationPayload: {
-            election: state.computationState.election,
             algorithm: state.computationState.algorithm,
             firstDivisor: state.computationState.firstDivisor,
             electionThreshold: state.computationState.electionThreshold,
@@ -69,6 +66,7 @@ function mapStateToProps(state: RootState): StateProps {
             votes: state.computationState.votes,
             metrics: state.computationState.metrics,
             parameters: state.computationState.parameters,
+            partyMap: state.requestedDataState.partyMap,
         },
         settingsPayload: {
             electionYears: state.settingsState.electionYears,
@@ -141,7 +139,6 @@ const mapDispatchToProps = (dispatch: any): DispatchProps => ({
     updateCalculation: (computationPayload: ComputationPayload, autoCompute: boolean, forceCompute: boolean) => {
         if (autoCompute || forceCompute) {
             const payload: ComputationPayload = {
-                election: computationPayload.election,
                 algorithm: computationPayload.algorithm,
                 firstDivisor: computationPayload.firstDivisor,
                 electionThreshold: computationPayload.electionThreshold,
@@ -152,6 +149,7 @@ const mapDispatchToProps = (dispatch: any): DispatchProps => ({
                 votes: computationPayload.votes,
                 metrics: computationPayload.metrics,
                 parameters: computationPayload.parameters,
+                partyMap: computationPayload.partyMap,
             };
             const updateCalculationAction = updateComputation(payload);
             dispatch(updateCalculationAction);

--- a/src/Layout/PresentationMenu/PresentationSettings/PresentationSettings.tsx
+++ b/src/Layout/PresentationMenu/PresentationSettings/PresentationSettings.tsx
@@ -118,7 +118,6 @@ export class PresentationSettingsMenu extends React.Component<PresentationSettin
 
         const year = this.props.year;
         let votes = this.props.votes.filter((vote) => vote.electionYear === year);
-        const tmpVotes = votes;
         const distributionYear = this.props.use2021Distribution && year >= 2005 ? 2021 : year;
         let metrics = this.props.metrics.filter((metric) => metric.electionYear === distributionYear);
         const parameters = this.props.parameters;
@@ -127,9 +126,6 @@ export class PresentationSettingsMenu extends React.Component<PresentationSettin
             if (shouldDistributeDistrictSeats(year) && event.target.checked) {
                 votes = mergeVoteDistricts(votes, districtMap);
                 metrics = mergeMetricDistricts(metrics, districtMap);
-            }
-            if (tmpVotes !== votes) {
-                console.log("Changed");
             }
 
             this.props.updateCalculation(

--- a/src/Layout/PresentationMenu/PresentationSettings/PresentationSettings.tsx
+++ b/src/Layout/PresentationMenu/PresentationSettings/PresentationSettings.tsx
@@ -7,13 +7,8 @@ import { NoSeatsCheckbox } from "./NoSeatsCheckbox";
 import { ComparisonCheckbox } from "./ComparisonCheckbox";
 import { FiltersCheckbox } from "./FiltersCheckbox";
 import { MergeDistrictsCheckbox } from "./MergeDistrictsCheckbox";
-import { ElectionType, Votes, Metrics, Parameters } from "../../../requested-data/requested-data-models";
-import {
-    mergeElectionDistricts,
-    districtMap,
-    mergeVoteDistricts,
-    mergeMetricDistricts,
-} from "../../../computation/logic/district-merging";
+import { Votes, Metrics, Parameters } from "../../../requested-data/requested-data-models";
+import { districtMap, mergeVoteDistricts, mergeMetricDistricts } from "../../../computation/logic/district-merging";
 import { ComputationMenuPayload } from "../../ComputationMenu/computation-menu-models";
 import { Use2021DistributionCheckbox } from "./Use2021DistributionCheckbox";
 import { shouldDistributeDistrictSeats } from "../../../utilities/conditionals";
@@ -39,7 +34,6 @@ export interface PresentationSettingsProps {
     toggleMergeDistricts: (checked: boolean) => void;
     use2021Distribution: boolean;
     toggleUse2021Distribution: (checked: boolean) => void;
-    electionType: ElectionType;
     votes: Votes[];
     metrics: Metrics[];
     parameters: Parameters;
@@ -123,23 +117,24 @@ export class PresentationSettingsMenu extends React.Component<PresentationSettin
         this.props.toggleMergeDistricts(event.target.checked);
 
         const year = this.props.year;
-        let election = this.props.electionType.elections.find((election) => election.year === year);
         let votes = this.props.votes.filter((vote) => vote.electionYear === year);
+        const tmpVotes = votes;
         const distributionYear = this.props.use2021Distribution && year >= 2005 ? 2021 : year;
         let metrics = this.props.metrics.filter((metric) => metric.electionYear === distributionYear);
         const parameters = this.props.parameters;
 
-        if (election !== undefined) {
+        if (votes.length > 0) {
             if (shouldDistributeDistrictSeats(year) && event.target.checked) {
-                election = mergeElectionDistricts(election, districtMap);
                 votes = mergeVoteDistricts(votes, districtMap);
                 metrics = mergeMetricDistricts(metrics, districtMap);
+            }
+            if (tmpVotes !== votes) {
+                console.log("Changed");
             }
 
             this.props.updateCalculation(
                 {
                     ...this.props.computationPayload,
-                    election,
                     metrics,
                     votes,
                     parameters,
@@ -158,17 +153,15 @@ export class PresentationSettingsMenu extends React.Component<PresentationSettin
         this.props.toggleUse2021Distribution(event.target.checked);
 
         const year = this.props.year;
-        const election = this.props.electionType.elections.find((election) => election.year === year);
         const votes = this.props.votes.filter((vote) => vote.electionYear === year);
         const metricsYear = event.target.checked && year >= 2005 ? 2021 : year;
         const metrics = this.props.metrics.filter((metric) => metric.electionYear === metricsYear);
         const parameters = this.props.parameters;
 
-        if (election !== undefined) {
+        if (votes.length > 0) {
             this.props.updateCalculation(
                 {
                     ...this.props.computationPayload,
-                    election,
                     metrics,
                     votes,
                     parameters,

--- a/src/computation/computation-actions.ts
+++ b/src/computation/computation-actions.ts
@@ -42,7 +42,7 @@ export function initializeComputation(
     votes: Votes[],
     metrics: Metrics[],
     parameters: Parameters[],
-    partyMap: Map<string, string>
+    partyMap: _.Dictionary<string>
 ) {
     const filterVotes: Votes[] = votes.filter((vote) => vote.electionYear === year);
     const filterMetrics: Metrics[] = metrics.filter((metric) => metric.electionYear === year);
@@ -153,7 +153,7 @@ export function updateHistorical(
     votes: Votes[],
     metrics: Metrics[],
     parameters: Parameters,
-    partyMap: Map<string, string>
+    partyMap: _.Dictionary<string>
 ) {
     const payload: ComputationPayload = {
         algorithm: parameters.algorithm.algorithm,

--- a/src/computation/computation-actions.ts
+++ b/src/computation/computation-actions.ts
@@ -2,7 +2,6 @@
 import { Votes, Metrics, Parameters, FirstDivisor } from "../requested-data/requested-data-models";
 import { lagueDhont } from "./logic";
 import { unloadedParameters } from "./computation-state";
-import { Dictionary } from "../utilities/dictionary";
 
 /**
  * Enum containing all possible ComputationAction types.
@@ -43,7 +42,7 @@ export function initializeComputation(
     votes: Votes[],
     metrics: Metrics[],
     parameters: Parameters[],
-    partyMap: Dictionary<string>
+    partyMap: Map<string, string>
 ) {
     const filterVotes: Votes[] = votes.filter((vote) => vote.electionYear === year);
     const filterMetrics: Metrics[] = metrics.filter((metric) => metric.electionYear === year);
@@ -154,7 +153,7 @@ export function updateHistorical(
     votes: Votes[],
     metrics: Metrics[],
     parameters: Parameters,
-    partyMap: Dictionary<string>
+    partyMap: Map<string, string>
 ) {
     const payload: ComputationPayload = {
         algorithm: parameters.algorithm.algorithm,

--- a/src/computation/computation-models.ts
+++ b/src/computation/computation-models.ts
@@ -1,4 +1,4 @@
-import { Election, Votes, Metrics, Parameters } from "../requested-data/requested-data-models";
+import { Votes, Metrics, Parameters } from "../requested-data/requested-data-models";
 import { Dictionary } from "../utilities/dictionary";
 
 export enum AlgorithmType {
@@ -11,7 +11,6 @@ export enum AlgorithmType {
 }
 
 export interface ComputationPayload {
-    election: Election;
     algorithm: AlgorithmType;
     firstDivisor: number;
     districtThreshold: number;
@@ -22,6 +21,7 @@ export interface ComputationPayload {
     votes: Votes[];
     metrics: Metrics[];
     parameters: Parameters;
+    partyMap: Dictionary<string>;
 }
 
 export interface DistrictResult {
@@ -164,18 +164,6 @@ export interface NationalPartyResult {
 export interface PartyResultv2 extends NationalPartyResult {
     /** The district which the results are from */
     district: string;
-}
-
-export interface Result {
-    resultId: number;
-    votes: number;
-    percentage: number;
-    electionId: number;
-    partyId: number;
-    countyId: number;
-    countyName: string;
-    partyCode: string;
-    partyName: string;
 }
 
 export interface SeatPartyResult {

--- a/src/computation/computation-models.ts
+++ b/src/computation/computation-models.ts
@@ -21,7 +21,7 @@ export interface ComputationPayload {
     votes: Votes[];
     metrics: Metrics[];
     parameters: Parameters;
-    partyMap: Dictionary<string>;
+    partyMap: Map<string, string>;
 }
 
 export interface DistrictResult {

--- a/src/computation/computation-models.ts
+++ b/src/computation/computation-models.ts
@@ -1,5 +1,4 @@
 import { Votes, Metrics, Parameters } from "../requested-data/requested-data-models";
-import { Dictionary } from "../utilities/dictionary";
 
 export enum AlgorithmType {
     SAINTE_LAGUE = "SAINTE_LAGUE",
@@ -21,7 +20,7 @@ export interface ComputationPayload {
     votes: Votes[];
     metrics: Metrics[];
     parameters: Parameters;
-    partyMap: Map<string, string>;
+    partyMap: _.Dictionary<string>;
 }
 
 export interface DistrictResult {
@@ -83,7 +82,7 @@ export interface PartyQuotient {
 
 export interface DistributionResult {
     /** A dictionary taking partyCodes and returning the matching number of seats won in this distribution */
-    seatsWon: Dictionary<number>;
+    seatsWon: _.Dictionary<number>;
     /** List of information regarding the distribution of the individual seats */
     seatResults: SeatResult[];
 }

--- a/src/computation/computation-reducer.ts
+++ b/src/computation/computation-reducer.ts
@@ -15,7 +15,6 @@ export function computation(state: ComputationState = unloadedState, action: Com
         case ComputationActionType.INITIALIZE_COMPUTATION:
             return {
                 ...state,
-                election: action.election,
                 algorithm: action.algorithm,
                 firstDivisor: action.firstDivisor,
                 electionThreshold: action.electionThreshold,
@@ -33,7 +32,6 @@ export function computation(state: ComputationState = unloadedState, action: Com
         case ComputationActionType.UPDATE_COMPUTATION:
             return {
                 ...state,
-                election: action.election,
                 algorithm: action.algorithm,
                 firstDivisor: action.firstDivisor,
                 electionThreshold: action.electionThreshold,

--- a/src/computation/computation-state.ts
+++ b/src/computation/computation-state.ts
@@ -1,8 +1,7 @@
 ﻿import { AlgorithmType, LagueDhontResult } from "./computation-models";
-import { Election, Votes, Metrics, Parameters } from "../requested-data/requested-data-models";
+import { Votes, Metrics, Parameters } from "../requested-data/requested-data-models";
 
 export interface ComputationState {
-    election: Election;
     algorithm: AlgorithmType;
     firstDivisor: number;
     electionThreshold: number;
@@ -33,18 +32,6 @@ export const unloadedParameters: Parameters = {
 };
 
 export const unloadedState: ComputationState = {
-    election: {
-        countryId: -1,
-        electionTypeId: -1,
-        electionId: -1,
-        counties: [],
-        year: -1,
-        algorithm: 0,
-        firstDivisor: -1,
-        threshold: -1,
-        seats: -1,
-        levelingSeats: -1,
-    },
     algorithm: AlgorithmType.UNDEFINED,
     firstDivisor: -1,
     electionThreshold: -1,

--- a/src/computation/logic/algorithm-utilities.ts
+++ b/src/computation/logic/algorithm-utilities.ts
@@ -7,7 +7,6 @@
     LevelingSeat,
     DistrictQuotients,
 } from "..";
-import { Dictionary } from "../../utilities/dictionary";
 import { SeatPartyResult } from "./../../computation/computation-models";
 import * as _ from "lodash";
 import { largestFraction } from "./distribution";
@@ -18,11 +17,11 @@ import { calculatePercent } from "../../utilities/number";
 const illegalPartyCodes = new Set(["BLANKE"]);
 
 export function constructDistrictResults(
-    districtSeats: Dictionary<number>,
-    districtVotes: Dictionary<number>,
+    districtSeats: _.Dictionary<number>,
+    districtVotes: _.Dictionary<number>,
     totalVotes: number
-): Dictionary<DistrictResult> {
-    const districtResults: Dictionary<DistrictResult> = {};
+): _.Dictionary<DistrictResult> {
+    const districtResults: _.Dictionary<DistrictResult> = {};
     for (const district in districtSeats) {
         if (districtSeats.hasOwnProperty(district)) {
             districtResults[district] = {
@@ -45,9 +44,9 @@ export function constructDistrictResults(
 export function constructPartyResults(
     votes: Votes[],
     totalVotes: number,
-    partyMap: Map<string, string>
-): Dictionary<PartyResult> {
-    const partyResults: Dictionary<PartyResult> = {};
+    partyMap: _.Dictionary<string>
+): _.Dictionary<PartyResult> {
+    const partyResults: _.Dictionary<PartyResult> = {};
 
     for (const vote of votes) {
         if (vote.party in partyResults) {
@@ -55,7 +54,7 @@ export function constructPartyResults(
         } else {
             partyResults[vote.party] = {
                 partyCode: vote.party,
-                partyName: partyMap.get(vote.party)!,
+                partyName: partyMap[vote.party],
                 votes: vote.votes,
                 percentVotes: 0,
                 districtSeats: 0,
@@ -78,10 +77,10 @@ export function constructPartyResults(
 
 export function constructDistrictPartyResults(
     votes: Votes[],
-    districtVotes: Dictionary<number>,
-    partyMap: Map<string, string>
-): Dictionary<Dictionary<PartyResult>> {
-    const districtPartyResults: Dictionary<Dictionary<PartyResult>> = {};
+    districtVotes: _.Dictionary<number>,
+    partyMap: _.Dictionary<string>
+): _.Dictionary<_.Dictionary<PartyResult>> {
+    const districtPartyResults: _.Dictionary<_.Dictionary<PartyResult>> = {};
 
     for (const vote of votes) {
         if (!districtPartyResults[vote.district]) {
@@ -89,7 +88,7 @@ export function constructDistrictPartyResults(
         }
         districtPartyResults[vote.district][vote.party] = {
             partyCode: vote.party,
-            partyName: partyMap.get(vote.party)!,
+            partyName: partyMap[vote.party],
             votes: vote.votes,
             percentVotes: calculatePercent(vote.votes, districtVotes[vote.district]),
             districtSeats: 0,
@@ -101,8 +100,8 @@ export function constructDistrictPartyResults(
     return districtPartyResults;
 }
 
-export function getVotesPerDistrict(votes: Votes[]): Dictionary<number> {
-    const voteCount: Dictionary<number> = {};
+export function getVotesPerDistrict(votes: Votes[]): _.Dictionary<number> {
+    const voteCount: _.Dictionary<number> = {};
     for (const vote of votes) {
         if (vote.district in voteCount) {
             voteCount[vote.district] += vote.votes;
@@ -130,9 +129,9 @@ export function distributeSeats(
     districtThreshold: number,
     numSeats: number,
     totalVotes: number,
-    results: Dictionary<PartyResult>,
+    results: _.Dictionary<PartyResult>,
     averageVotesPerSeat?: number,
-    partyResults?: Dictionary<PartyResult>
+    partyResults?: _.Dictionary<PartyResult>
 ): DistributionResult {
     if (isLargestFractionAlgorithm(algorithm)) {
         const electionNumber = getElectionNumber(algorithm, totalVotes, numSeats);
@@ -140,8 +139,8 @@ export function distributeSeats(
         return largestFraction(numSeats, partyVotes, electionNumber);
     }
 
-    const seatsWon: Dictionary<number> = {};
-    const currentSeatsWon: Dictionary<number> = {};
+    const seatsWon: _.Dictionary<number> = {};
+    const currentSeatsWon: _.Dictionary<number> = {};
     const seatResults: SeatResult[] = [];
 
     if (partyResults === undefined) {
@@ -311,9 +310,9 @@ function getElectionNumber(algorithm: AlgorithmType, totalVotes: number, totalSe
  */
 export function calculateProportionality(
     totalSeats: number,
-    partyResults: Dictionary<PartyResult>,
-    districtPartyResults: Dictionary<Dictionary<PartyResult>>,
-    districtResults: Dictionary<DistrictResult>
+    partyResults: _.Dictionary<PartyResult>,
+    districtPartyResults: _.Dictionary<_.Dictionary<PartyResult>>,
+    districtResults: _.Dictionary<DistrictResult>
 ) {
     for (const partyCode in partyResults) {
         if (partyResults.hasOwnProperty(partyCode) && !illegalPartyCodes.has(partyCode)) {
@@ -374,7 +373,7 @@ export function calculateQuotient(
  * Calculates the total number of seats and the average number of votes per seat for each district
  * @param districtResults The district results to finalize
  */
-export function finalizeDistrictCalculations(districtResults: Dictionary<DistrictResult>) {
+export function finalizeDistrictCalculations(districtResults: _.Dictionary<DistrictResult>) {
     for (const district in districtResults) {
         if (districtResults.hasOwnProperty(district)) {
             districtResults[district].totalSeats =
@@ -389,7 +388,7 @@ export function calculateFinalQuotients(
     algorithm: AlgorithmType,
     firstDivisor: number,
     adjusted: boolean,
-    districtResults: Dictionary<DistrictResult>
+    districtResults: _.Dictionary<DistrictResult>
 ): DistrictQuotients[] {
     const finalQuotients: DistrictQuotients[] = [];
     for (const districtName in districtResults) {
@@ -438,9 +437,9 @@ export function calculateFinalQuotients(
 /**
  * Sorts a list of leveling seats as described here: https://lovdata.no/NL/lov/2002-06-28-57/§11-6
  * @param levelingSeats The list of leveling seats to be sorted
- * @param partyResults A dictionary used to look up how many votes the parties got
+ * @param partyResults A _.Dictionary used to look up how many votes the parties got
  */
-export function sortLevelingSeats(levelingSeats: LevelingSeat[], partyResults: Dictionary<PartyResult>) {
+export function sortLevelingSeats(levelingSeats: LevelingSeat[], partyResults: _.Dictionary<PartyResult>) {
     return levelingSeats.sort((v, t) => {
         if (t.quotient !== v.quotient) {
             return t.quotient - v.quotient;
@@ -457,9 +456,9 @@ export function sortLevelingSeats(levelingSeats: LevelingSeat[], partyResults: D
 export function generateLevelingSeatArray(
     algorithm: AlgorithmType,
     levelingPartyCodes: string[],
-    partyResults: Dictionary<PartyResult>,
-    districtResults: Dictionary<DistrictResult>,
-    districtPartyResults: Dictionary<Dictionary<PartyResult>>,
+    partyResults: _.Dictionary<PartyResult>,
+    districtResults: _.Dictionary<DistrictResult>,
+    districtPartyResults: _.Dictionary<_.Dictionary<PartyResult>>,
     useAdjustedQuotient: boolean
 ): LevelingSeat[] {
     let levelingSeats: LevelingSeat[] = [];
@@ -505,12 +504,12 @@ export function generateLevelingSeatArray(
 }
 
 /**
- * Converts an array of results to a dictionary from Party Code to Votes.
+ * Converts an array of results to a Dictionary from Party Code to Votes.
  *
  * @param results An array of results
  */
-function resultArrayToDictionary(results: Dictionary<PartyResult>): Dictionary<number> {
-    const resultDict: Dictionary<number> = {};
+function resultArrayToDictionary(results: _.Dictionary<PartyResult>): _.Dictionary<number> {
+    const resultDict: _.Dictionary<number> = {};
     for (const partyCode in results) {
         if (results.hasOwnProperty(partyCode)) {
             const partyVotes = results[partyCode];

--- a/src/computation/logic/algorithm-utilities.ts
+++ b/src/computation/logic/algorithm-utilities.ts
@@ -45,7 +45,7 @@ export function constructDistrictResults(
 export function constructPartyResults(
     votes: Votes[],
     totalVotes: number,
-    partyMap: Dictionary<string>
+    partyMap: Map<string, string>
 ): Dictionary<PartyResult> {
     const partyResults: Dictionary<PartyResult> = {};
 
@@ -55,7 +55,7 @@ export function constructPartyResults(
         } else {
             partyResults[vote.party] = {
                 partyCode: vote.party,
-                partyName: partyMap[vote.party],
+                partyName: partyMap.get(vote.party)!,
                 votes: vote.votes,
                 percentVotes: 0,
                 districtSeats: 0,
@@ -79,7 +79,7 @@ export function constructPartyResults(
 export function constructDistrictPartyResults(
     votes: Votes[],
     districtVotes: Dictionary<number>,
-    partyMap: Dictionary<string>
+    partyMap: Map<string, string>
 ): Dictionary<Dictionary<PartyResult>> {
     const districtPartyResults: Dictionary<Dictionary<PartyResult>> = {};
 
@@ -89,7 +89,7 @@ export function constructDistrictPartyResults(
         }
         districtPartyResults[vote.district][vote.party] = {
             partyCode: vote.party,
-            partyName: partyMap[vote.party],
+            partyName: partyMap.get(vote.party)!,
             votes: vote.votes,
             percentVotes: calculatePercent(vote.votes, districtVotes[vote.district]),
             districtSeats: 0,

--- a/src/computation/logic/algorithm-utilities.ts
+++ b/src/computation/logic/algorithm-utilities.ts
@@ -633,3 +633,7 @@ export function isLargestFractionAlgorithm(algorithm: AlgorithmType): boolean {
         algorithm === AlgorithmType.LARGEST_FRACTION_HAGENBACH_BISCHOFF
     );
 }
+
+export function shouldApply2005Reform(year: number) {
+    return year >= 2005;
+}

--- a/src/computation/logic/distribute-levelling-seats.ts
+++ b/src/computation/logic/distribute-levelling-seats.ts
@@ -3,7 +3,7 @@ import { Dictionary, dictionaryToArray } from "../../utilities/dictionary";
 import { distributeSeats } from ".";
 import { distributeLevelingSeatsOnDistricts, distributeLevelingSeatsOnDistrictsPre2005 } from "./utils";
 import { DistributionResult, NationalDistributionResult } from "../../computation/computation-models";
-import { isLargestFractionAlgorithm, isQuotientAlgorithm } from "./algorithm-utilities";
+import { isLargestFractionAlgorithm, isQuotientAlgorithm, shouldApply2005Reform } from "./algorithm-utilities";
 
 /**
  * Distributes the leveling seats on the parties and on each district.
@@ -47,9 +47,8 @@ export function distributeLevelingSeats(
     const wonLevelingPartyCodes = levelingPartyCodes.filter((partyCode) => partyResults[partyCode].levelingSeats > 0);
 
     let partyRestQuotients: Dictionary<PartyRestQuotients> = {};
-    const preOneLevelingSeatPerDistrict = payload.parameters.electionYear < 2005;
-    if (preOneLevelingSeatPerDistrict) {
-        partyRestQuotients = distributeLevelingSeatsOnDistrictsPre2005(
+    if (shouldApply2005Reform(payload.parameters.electionYear)) {
+        partyRestQuotients = distributeLevelingSeatsOnDistricts(
             payload,
             wonLevelingPartyCodes,
             partyResults,
@@ -57,7 +56,7 @@ export function distributeLevelingSeats(
             districtResults
         );
     } else {
-        partyRestQuotients = distributeLevelingSeatsOnDistricts(
+        partyRestQuotients = distributeLevelingSeatsOnDistrictsPre2005(
             payload,
             wonLevelingPartyCodes,
             partyResults,

--- a/src/computation/logic/distribute-levelling-seats.ts
+++ b/src/computation/logic/distribute-levelling-seats.ts
@@ -1,5 +1,5 @@
 import { ComputationPayload, PartyResult, DistrictResult, PartyRestQuotients } from "..";
-import { Dictionary, dictionaryToArray } from "../../utilities/dictionary";
+import { dictionaryToArray } from "../../utilities/dictionary";
 import { distributeSeats } from ".";
 import { distributeLevelingSeatsOnDistricts, distributeLevelingSeatsOnDistrictsPre2005 } from "./utils";
 import { DistributionResult, NationalDistributionResult } from "../../computation/computation-models";
@@ -15,9 +15,9 @@ import { isLargestFractionAlgorithm, isQuotientAlgorithm, shouldApply2005Reform 
  */
 export function distributeLevelingSeats(
     payload: ComputationPayload,
-    partyResults: Dictionary<PartyResult>,
-    districtPartyResults: Dictionary<Dictionary<PartyResult>>,
-    districtResults: Dictionary<DistrictResult>
+    partyResults: _.Dictionary<PartyResult>,
+    districtPartyResults: _.Dictionary<_.Dictionary<PartyResult>>,
+    districtResults: _.Dictionary<DistrictResult>
 ): PartyRestQuotients[] {
     const allPartyCodes = [...Object.keys(partyResults)];
     // Filter out parties with less than the threshold
@@ -46,7 +46,7 @@ export function distributeLevelingSeats(
 
     const wonLevelingPartyCodes = levelingPartyCodes.filter((partyCode) => partyResults[partyCode].levelingSeats > 0);
 
-    let partyRestQuotients: Dictionary<PartyRestQuotients> = {};
+    let partyRestQuotients: _.Dictionary<PartyRestQuotients> = {};
     if (shouldApply2005Reform(payload.parameters.electionYear)) {
         partyRestQuotients = distributeLevelingSeatsOnDistricts(
             payload,
@@ -80,11 +80,11 @@ export function distributeLevelingSeats(
 function nationalDistributionFilter(
     levelingPartyCodes: string[],
     payload: ComputationPayload,
-    partyResults: Dictionary<PartyResult>
+    partyResults: _.Dictionary<PartyResult>
 ): NationalDistributionResult {
     let totalVotes = 0;
     let seatsToDistribute = payload.levelingSeats;
-    const levelingParties: Dictionary<PartyResult> = {};
+    const levelingParties: _.Dictionary<PartyResult> = {};
     for (const partyCode of levelingPartyCodes) {
         totalVotes += partyResults[partyCode].votes;
         seatsToDistribute += partyResults[partyCode].districtSeats;
@@ -137,7 +137,7 @@ function nationalDistributionFilter(
  */
 function finalLevelingSeatDistribution(
     levelingPartyCodes: string[],
-    partyResults: Dictionary<PartyResult>,
+    partyResults: _.Dictionary<PartyResult>,
     payload: ComputationPayload,
     nationalDistribution: DistributionResult
 ): DistributionResult {
@@ -163,11 +163,11 @@ function finalLevelingSeatDistribution(
  */
 function finalQuotientLevelingSeatDistribution(
     levelingPartyCodes: string[],
-    partyResults: Dictionary<PartyResult>,
+    partyResults: _.Dictionary<PartyResult>,
     payload: ComputationPayload
 ) {
     let totalVotes = 0;
-    const levelingParties: Dictionary<PartyResult> = {};
+    const levelingParties: _.Dictionary<PartyResult> = {};
     for (const partyCode of levelingPartyCodes) {
         totalVotes += partyResults[partyCode].votes;
         const party: PartyResult = {
@@ -205,10 +205,10 @@ function finalQuotientLevelingSeatDistribution(
  */
 function finalLargestFractionLevelingSeatDistribution(
     levelingPartyCodes: string[],
-    partyResults: Dictionary<PartyResult>,
+    partyResults: _.Dictionary<PartyResult>,
     nationalDistribution: DistributionResult
 ): DistributionResult {
-    const levelingSeatDistribution: Dictionary<number> = {};
+    const levelingSeatDistribution: _.Dictionary<number> = {};
     levelingPartyCodes.forEach((partyCode) => {
         levelingSeatDistribution[partyCode] =
             nationalDistribution.seatsWon[partyCode] - partyResults[partyCode].districtSeats;

--- a/src/computation/logic/distribute-levelling-seats.ts
+++ b/src/computation/logic/distribute-levelling-seats.ts
@@ -1,4 +1,4 @@
-import { ComputationPayload, PartyResult, DistrictResult, PartyRestQuotients, Result } from "..";
+import { ComputationPayload, PartyResult, DistrictResult, PartyRestQuotients } from "..";
 import { Dictionary, dictionaryToArray } from "../../utilities/dictionary";
 import { distributeSeats } from ".";
 import { distributeLevelingSeatsOnDistricts, distributeLevelingSeatsOnDistrictsPre2005 } from "./utils";
@@ -47,7 +47,7 @@ export function distributeLevelingSeats(
     const wonLevelingPartyCodes = levelingPartyCodes.filter((partyCode) => partyResults[partyCode].levelingSeats > 0);
 
     let partyRestQuotients: Dictionary<PartyRestQuotients> = {};
-    const preOneLevelingSeatPerDistrict = payload.election.year < 2005;
+    const preOneLevelingSeatPerDistrict = payload.parameters.electionYear < 2005;
     if (preOneLevelingSeatPerDistrict) {
         partyRestQuotients = distributeLevelingSeatsOnDistrictsPre2005(
             payload,
@@ -85,22 +85,21 @@ function nationalDistributionFilter(
 ): NationalDistributionResult {
     let totalVotes = 0;
     let seatsToDistribute = payload.levelingSeats;
-    const levelingParties: Result[] = [];
+    const levelingParties: Dictionary<PartyResult> = {};
     for (const partyCode of levelingPartyCodes) {
         totalVotes += partyResults[partyCode].votes;
         seatsToDistribute += partyResults[partyCode].districtSeats;
-        const party: Result = {
-            countyId: -1,
-            electionId: -1,
-            partyId: -1,
-            resultId: -1,
-            countyName: "",
+        const party: PartyResult = {
+            districtSeats: -1,
+            levelingSeats: -1,
             partyCode,
             partyName: "",
+            percentVotes: -1,
+            proportionality: -1,
+            totalSeats: -1,
             votes: partyResults[partyCode].votes,
-            percentage: -1,
         };
-        levelingParties.push(party);
+        levelingParties[partyCode] = party;
     }
 
     // Compute the distribution of the total number of seats on the whole country
@@ -169,21 +168,20 @@ function finalQuotientLevelingSeatDistribution(
     payload: ComputationPayload
 ) {
     let totalVotes = 0;
-    const levelingParties = [];
+    const levelingParties: Dictionary<PartyResult> = {};
     for (const partyCode of levelingPartyCodes) {
         totalVotes += partyResults[partyCode].votes;
-        const party: Result = {
-            countyId: -1,
-            electionId: -1,
-            partyId: -1,
-            resultId: -1,
-            countyName: "",
+        const party: PartyResult = {
+            districtSeats: -1,
+            levelingSeats: -1,
             partyCode,
             partyName: "",
+            percentVotes: -1,
+            proportionality: -1,
+            totalSeats: -1,
             votes: partyResults[partyCode].votes,
-            percentage: partyResults[partyCode].percentVotes,
         };
-        levelingParties.push(party);
+        levelingParties[partyCode] = party;
     }
 
     // Distribute the leveling seats, taking the district seats into account

--- a/src/computation/logic/distribution.ts
+++ b/src/computation/logic/distribution.ts
@@ -1,4 +1,4 @@
-import { copyDictionary, Dictionary } from "../../utilities/dictionary";
+import { copyDictionary } from "../../utilities/dictionary";
 import { QuotientDictionary } from "./quotient-dictionary";
 import { SortedReverseDict } from "./sorted-reverse-dict";
 import { breakTies } from "./utils";
@@ -17,10 +17,10 @@ import { DistributionResult } from "../computation-models";
  */
 export function distributionByQuotient(
     numberToDistribute: number,
-    distributeOn: Dictionary<number>,
-    baseValue: Dictionary<number>,
+    distributeOn: _.Dictionary<number>,
+    baseValue: _.Dictionary<number>,
     denominatorFunction: (timesWon: number) => number
-): Dictionary<number> {
+): _.Dictionary<number> {
     const updatedDistribution = copyDictionary(distributeOn);
     const quotientDictionary = new QuotientDictionary(denominatorFunction);
     quotientDictionary.populateQuotients(updatedDistribution, baseValue);
@@ -73,7 +73,7 @@ export function dHondt(numberOfSeatsAssigned: number): number {
  */
 export function largestFraction(
     numberToDistribute: number,
-    partyVotes: Dictionary<number>,
+    partyVotes: _.Dictionary<number>,
     electionNumber: number
 ): DistributionResult {
     const { ratedParties, seatsWon, seatsDistributed } = distributeWholeSeats(partyVotes, electionNumber);
@@ -92,11 +92,11 @@ export function largestFraction(
 }
 
 function distributeWholeSeats(
-    partyVotes: Dictionary<number>,
+    partyVotes: _.Dictionary<number>,
     electionNumber: number
-): { ratedParties: SortedReverseDict; seatsWon: Dictionary<number>; seatsDistributed: number } {
+): { ratedParties: SortedReverseDict; seatsWon: _.Dictionary<number>; seatsDistributed: number } {
     const ratedParties = new SortedReverseDict();
-    const seatsWon: Dictionary<number> = {};
+    const seatsWon: _.Dictionary<number> = {};
     let seatsDistributed = 0;
     for (const partyCode in partyVotes) {
         if (partyVotes.hasOwnProperty(partyCode)) {

--- a/src/computation/logic/district-merging.ts
+++ b/src/computation/logic/district-merging.ts
@@ -1,5 +1,5 @@
-import { Election, County, Result, Votes, Metrics } from "../../requested-data/requested-data-models";
-import { mapAddFromArray, mapAdd } from "../../utilities/map";
+import { Votes, Metrics } from "../../requested-data/requested-data-models";
+import { mapAdd } from "../../utilities/map";
 
 export const districtMap: Map<string, string> = new Map<string, string>([
     ["Nord-Trøndelag", "Trøndelag"],
@@ -19,128 +19,6 @@ export const districtMap: Map<string, string> = new Map<string, string>([
     ["Finnmark", "Troms og Finnmark"],
 ]);
 
-export function mergeElectionDistricts(election: Election, districtMap: Map<string, string>): Election {
-    const { finishedDistricts, groupedDistricts, groupedResults } = groupDistrictsAndResults(
-        election.counties,
-        districtMap
-    );
-    const mergedDistricts = mergeDistrictsAndResults(groupedDistricts, groupedResults);
-    const result = finishedDistricts.concat(mergedDistricts);
-
-    return {
-        algorithm: election.algorithm,
-        counties: result,
-        countryId: election.countryId,
-        electionId: election.electionId,
-        electionTypeId: election.electionTypeId,
-        firstDivisor: election.firstDivisor,
-        levelingSeats: election.levelingSeats,
-        seats: election.seats,
-        threshold: election.threshold,
-        year: election.year,
-    };
-}
-
-function groupDistrictsAndResults(
-    districts: County[],
-    districtMap: Map<string, string>
-): {
-    finishedDistricts: County[];
-    groupedDistricts: Map<string, County[]>;
-    groupedResults: Map<string, Map<string, Result[]>>;
-} {
-    const finishedDistricts: County[] = [];
-    let groupedDistricts = new Map<string, County[]>();
-    const groupedResults = new Map<string, Map<string, Result[]>>();
-
-    for (let i = 0, n = districts.length; i < n; i++) {
-        const currentDistrict = districts[i];
-        const newName = districtMap.get(currentDistrict.name);
-
-        if (newName === undefined) {
-            finishedDistricts.push(currentDistrict);
-        } else {
-            if (!groupedResults.has(newName)) {
-                groupedResults.set(newName, new Map<string, Result[]>());
-            }
-            let results = groupedResults.get(newName);
-            if (results !== undefined) {
-                results = mapAddFromArray(results, getKeyFromResult, currentDistrict.results);
-                groupedResults.set(newName, results);
-            }
-            groupedDistricts = mapAdd(groupedDistricts, newName, currentDistrict);
-        }
-    }
-
-    return {
-        finishedDistricts,
-        groupedDistricts,
-        groupedResults,
-    };
-}
-
-function getKeyFromResult(result: Result): string {
-    return result.partyCode;
-}
-
-function mergeDistrictsAndResults(
-    groupedDistricts: Map<string, County[]>,
-    groupedResults: Map<string, Map<string, Result[]>>
-): County[] {
-    const finishedDistricts: County[] = [];
-
-    groupedDistricts.forEach((districtArray, districtName) => {
-        const resultMap = groupedResults.get(districtName);
-
-        if (resultMap !== undefined) {
-            const districtResults = mergeResults(resultMap, districtName);
-            const mergedDistrict = districtArray.reduce(districtReducer);
-            mergedDistrict.name = districtName;
-            mergedDistrict.results = districtResults;
-            finishedDistricts.push(mergedDistrict);
-        }
-    });
-
-    return finishedDistricts;
-}
-
-function mergeResults(resultMap: Map<string, Result[]>, districtName: string): Result[] {
-    const districtResults: Result[] = [];
-
-    resultMap.forEach((partyResults, _) => {
-        const mergedPartyResults = partyResults.reduce(resultReducer);
-        mergedPartyResults.countyName = districtName;
-        districtResults.push(mergedPartyResults);
-    });
-
-    return districtResults;
-}
-
-function resultReducer(result: Result, current: Result): Result {
-    return {
-        countyId: current.countyId,
-        countyName: "PLACEHOLDER",
-        electionId: current.electionId,
-        partyCode: current.partyCode,
-        partyId: current.partyId,
-        partyName: current.partyName,
-        percentage: result.percentage + current.percentage,
-        resultId: current.resultId,
-        votes: result.votes + current.votes,
-    };
-}
-
-function districtReducer(result: County, current: County): County {
-    return {
-        countryId: current.countryId,
-        countyId: current.countyId,
-        electionId: current.electionId,
-        name: "PLACEHOLDER",
-        results: [],
-        seats: result.seats + current.seats,
-    };
-}
-
 export function mergeVoteDistricts(votes: Votes[], districtMap: Map<string, string>): Votes[] {
     const { finishedVotes, groupedVotes } = groupVotes(votes, districtMap);
     const mergedVotes = mergeVotes(groupedVotes);
@@ -157,7 +35,7 @@ function groupVotes(
     const groupedVotes = new Map<string, Map<string, Votes[]>>();
 
     for (let i = 0, n = votes.length; i < n; i++) {
-        const currentVote = votes[i];
+        const currentVote = { ...votes[i] };
         const newName = districtMap.get(currentVote.district);
 
         if (newName === undefined) {
@@ -166,10 +44,10 @@ function groupVotes(
             if (!groupedVotes.has(newName)) {
                 groupedVotes.set(newName, new Map<string, Votes[]>());
             }
-            let votes = groupedVotes.get(newName);
-            if (votes !== undefined) {
-                votes = mapAdd(votes, currentVote.party, currentVote);
-                groupedVotes.set(newName, votes!);
+            let voteMap = groupedVotes.get(newName);
+            if (voteMap !== undefined) {
+                voteMap = mapAdd(voteMap, currentVote.party, currentVote);
+                groupedVotes.set(newName, voteMap!);
             }
         }
     }

--- a/src/computation/logic/district-merging.ts
+++ b/src/computation/logic/district-merging.ts
@@ -45,7 +45,7 @@ function groupVotes(
                 groupedVotes.set(newName, new Map<string, Votes[]>());
             }
             let voteMap = groupedVotes.get(newName);
-            if (voteMap !== undefined) {
+            if (voteMap) {
                 voteMap = mapAdd(voteMap, currentVote.party, currentVote);
                 groupedVotes.set(newName, voteMap!);
             }

--- a/src/computation/logic/execute-algorithm.ts
+++ b/src/computation/logic/execute-algorithm.ts
@@ -1,11 +1,10 @@
 import { ComputationPayload, DistrictResultv2, PartyResultv2, NationalPartyResult } from "../computation-models";
-import { Dictionary } from "../../utilities/dictionary";
 import { buildDistrictResults, sumAllVotes, calculatePercentages } from "./utils";
 
 export function lagueDhont(payload: ComputationPayload) {
-    const districtResults: Dictionary<DistrictResultv2> = buildDistrictResults(payload.metrics);
-    const partyResults: Dictionary<Dictionary<PartyResultv2>> = {};
-    const nationalPartyResults: Dictionary<NationalPartyResult> = {};
+    const districtResults: _.Dictionary<DistrictResultv2> = buildDistrictResults(payload.metrics);
+    const partyResults: _.Dictionary<_.Dictionary<PartyResultv2>> = {};
+    const nationalPartyResults: _.Dictionary<NationalPartyResult> = {};
 
     sumAllVotes(payload, districtResults, partyResults, nationalPartyResults);
     calculatePercentages(payload.parameters.totalVotes, districtResults, partyResults, nationalPartyResults);

--- a/src/computation/logic/lague-dhondt.ts
+++ b/src/computation/logic/lague-dhondt.ts
@@ -11,6 +11,7 @@ import {
     getVotesPerDistrict,
     constructPartyResults,
     constructDistrictPartyResults,
+    shouldApply2005Reform,
 } from "./algorithm-utilities";
 import { toSum } from "../../utilities/reduce";
 
@@ -68,8 +69,8 @@ export function lagueDhont(payload: ComputationPayload): LagueDhontResult {
     const districtResultArray = dictionaryToArray(districtResults);
     const partyResultArray = dictionaryToArray(partyResults);
 
-    const didElectionUseAdjustedQuotients = payload.parameters.electionYear >= 2005;
-    const useAdjustedQuotients = didElectionUseAdjustedQuotients && isQuotientAlgorithm(payload.algorithm);
+    const useAdjustedQuotients =
+        shouldApply2005Reform(payload.parameters.electionYear) && isQuotientAlgorithm(payload.algorithm);
     const finalQuotients = calculateFinalQuotients(
         payload.algorithm,
         payload.firstDivisor,

--- a/src/computation/logic/quotient-dictionary.ts
+++ b/src/computation/logic/quotient-dictionary.ts
@@ -1,5 +1,4 @@
 import { SortedReverseDict, KeyValuePair } from "./sorted-reverse-dict";
-import { Dictionary } from "../../utilities/dictionary";
 import { breakTies } from "./utils";
 
 export class QuotientDictionary extends SortedReverseDict {
@@ -28,7 +27,7 @@ export class QuotientDictionary extends SortedReverseDict {
      *
      * @param partyVotes Number of votes received by each party
      */
-    getWinner(partyVotes: Dictionary<number>): KeyValuePair {
+    getWinner(partyVotes: _.Dictionary<number>): KeyValuePair {
         const winners = this.popTop();
         let winner: KeyValuePair;
 
@@ -56,7 +55,7 @@ export class QuotientDictionary extends SortedReverseDict {
      * @param distribution Number of seats won by each party
      * @param partyVotes Number of votes received by each party
      */
-    populateQuotients(distribution: Dictionary<number>, partyVotes: Dictionary<number>) {
+    populateQuotients(distribution: _.Dictionary<number>, partyVotes: _.Dictionary<number>) {
         for (const entry in distribution) {
             if (distribution.hasOwnProperty(entry)) {
                 this.insertParty(entry, partyVotes[entry], distribution[entry]);

--- a/src/computation/logic/utils.ts
+++ b/src/computation/logic/utils.ts
@@ -1,4 +1,4 @@
-import { Dictionary, copyDictionary } from "../../utilities/dictionary";
+import { copyDictionary } from "../../utilities/dictionary";
 import {
     DistrictResultv2,
     PartyResultv2,
@@ -15,8 +15,8 @@ import { generateLevelingSeatArray } from ".";
 import { KeyValuePair } from "./sorted-reverse-dict";
 import { AlgorithmType } from "../computation-models";
 
-export function buildDistrictResults(metrics: Metrics[]): Dictionary<DistrictResultv2> {
-    const districtResults: Dictionary<DistrictResultv2> = {};
+export function buildDistrictResults(metrics: Metrics[]): _.Dictionary<DistrictResultv2> {
+    const districtResults: _.Dictionary<DistrictResultv2> = {};
 
     // Create an object for each district containing information about the district wide results
     metrics.map(
@@ -37,9 +37,9 @@ export function buildDistrictResults(metrics: Metrics[]): Dictionary<DistrictRes
 
 export function sumAllVotes(
     payload: ComputationPayload,
-    districtResults: Dictionary<DistrictResultv2>,
-    partyResults: Dictionary<Dictionary<PartyResultv2>>,
-    nationalPartyResults: Dictionary<NationalPartyResult>
+    districtResults: _.Dictionary<DistrictResultv2>,
+    partyResults: _.Dictionary<_.Dictionary<PartyResultv2>>,
+    nationalPartyResults: _.Dictionary<NationalPartyResult>
 ) {
     // Create an object for each party containing information about it's results by district
     payload.votes.forEach((vote) => {
@@ -79,9 +79,9 @@ export function sumAllVotes(
 
 export function calculatePercentages(
     totalVotes: number,
-    districtResults: Dictionary<DistrictResultv2>,
-    partyResults: Dictionary<Dictionary<PartyResultv2>>,
-    nationalPartyResults: Dictionary<NationalPartyResult>
+    districtResults: _.Dictionary<DistrictResultv2>,
+    partyResults: _.Dictionary<_.Dictionary<PartyResultv2>>,
+    nationalPartyResults: _.Dictionary<NationalPartyResult>
 ) {
     // Iterate over all parties
     for (const party in partyResults) {
@@ -119,8 +119,8 @@ export function distributeDistrictSeatsOnDistricts(
     levelingSeats: number,
     numDistrictSeats: number,
     metrics: Metrics[]
-): Dictionary<number> {
-    const baseValues: Dictionary<number> = {};
+): _.Dictionary<number> {
+    const baseValues: _.Dictionary<number> = {};
 
     // Wrap Sainte Lagues so it only takes one argument
     function denominatorFunction(seatsWon: number): number {
@@ -129,11 +129,11 @@ export function distributeDistrictSeatsOnDistricts(
 
     if (areaFactor === -1) {
         // If we don't have an area factor, just return the predetermined values
-        const districtSeats: Dictionary<number> = {};
+        const districtSeats: _.Dictionary<number> = {};
         metrics.forEach((metric) => (districtSeats[metric.district] = metric.seats));
         return districtSeats;
     } else {
-        const districtSeats: Dictionary<number> = {};
+        const districtSeats: _.Dictionary<number> = {};
         metrics.forEach((metric) => {
             // Fill districtSeats with all the districts, with no wins yet
             districtSeats[metric.district] = 0;
@@ -161,7 +161,7 @@ export function distributeDistrictSeatsOnDistricts(
  *
  * @param seatMapping The mapping between district and number of seats to subtract from
  */
-function subtractLevelingSeats(seatMapping: Dictionary<number>): Dictionary<number> {
+function subtractLevelingSeats(seatMapping: _.Dictionary<number>): _.Dictionary<number> {
     const copyMapping = copyDictionary(seatMapping);
 
     for (const name in copyMapping) {
@@ -176,15 +176,15 @@ function subtractLevelingSeats(seatMapping: Dictionary<number>): Dictionary<numb
 export function distributeLevelingSeatsOnDistricts(
     payload: ComputationPayload,
     levelingPartyCodes: string[],
-    partyResults: Dictionary<PartyResult>,
-    districtPartyResults: Dictionary<Dictionary<PartyResult>>,
-    districtResults: Dictionary<DistrictResult>
-): Dictionary<PartyRestQuotients> {
+    partyResults: _.Dictionary<PartyResult>,
+    districtPartyResults: _.Dictionary<_.Dictionary<PartyResult>>,
+    districtResults: _.Dictionary<DistrictResult>
+): _.Dictionary<PartyRestQuotients> {
     let finishedDistricts: string[] = [];
     let levelingSeats: LevelingSeat[] = [];
-    const partyRestQuotients: Dictionary<PartyRestQuotients> = {};
+    const partyRestQuotients: _.Dictionary<PartyRestQuotients> = {};
 
-    const partySeats: Dictionary<number> = {};
+    const partySeats: _.Dictionary<number> = {};
     let seatIndex = 1;
     let quotientIndex = 1;
     while (seatIndex <= payload.levelingSeats) {
@@ -236,14 +236,14 @@ export function distributeLevelingSeatsOnDistricts(
 export function distributeLevelingSeatsOnDistrictsPre2005(
     payload: ComputationPayload,
     levelingPartyCodes: string[],
-    partyResults: Dictionary<PartyResult>,
-    districtPartyResults: Dictionary<Dictionary<PartyResult>>,
-    districtResults: Dictionary<DistrictResult>
-): Dictionary<PartyRestQuotients> {
+    partyResults: _.Dictionary<PartyResult>,
+    districtPartyResults: _.Dictionary<_.Dictionary<PartyResult>>,
+    districtResults: _.Dictionary<DistrictResult>
+): _.Dictionary<PartyRestQuotients> {
     let levelingSeats: LevelingSeat[] = [];
-    const partyRestQuotients: Dictionary<PartyRestQuotients> = {};
+    const partyRestQuotients: _.Dictionary<PartyRestQuotients> = {};
 
-    const partySeats: Dictionary<number> = {};
+    const partySeats: _.Dictionary<number> = {};
     let seatIndex = 1;
     let quotientIndex = 1;
     while (seatIndex <= payload.levelingSeats) {
@@ -293,7 +293,7 @@ export function distributeLevelingSeatsOnDistrictsPre2005(
  *
  * @param districtSeats The distribution of district seats to check
  */
-function anyNegativeSeats(districtSeats: Dictionary<number>): boolean {
+function anyNegativeSeats(districtSeats: _.Dictionary<number>): boolean {
     for (const districtName in districtSeats) {
         if (districtSeats.hasOwnProperty(districtName)) {
             if (districtSeats[districtName] < 0) {
@@ -308,9 +308,9 @@ function anyNegativeSeats(districtSeats: Dictionary<number>): boolean {
  * Breaks ties in the distribution of items on names
  *
  * @param winners The list of multiple winners from the distribution stage
- * @param baseValue The dictionary from winners to their respective numerators
+ * @param baseValue The _.Dictionary from winners to their respective numerators
  */
-export function breakTies(winners: KeyValuePair[], baseValue: Dictionary<number>): KeyValuePair {
+export function breakTies(winners: KeyValuePair[], baseValue: _.Dictionary<number>): KeyValuePair {
     const winnersCopy = [...winners];
 
     // Find the highest numerator of the winners

--- a/src/requested-data/requested-data-actions.ts
+++ b/src/requested-data/requested-data-actions.ts
@@ -1,32 +1,24 @@
-﻿import { ElectionType, Votes, Metrics, Parameters } from "./requested-data-models";
+﻿import { Votes, Metrics, Parameters } from "./requested-data-models";
+import { Dictionary } from "../utilities/dictionary";
 
 /**
  * Enum containing all possible RequestedDataAction types.
  */
 export enum RequestedDataActionType {
-    INITIALIZE_REQUESTED_DATA = "INITIALIZE_REQUESTED_DATA",
     INTIIALIZE_REQUESTED_VOTES = "INITIALIZE_REQUESTED_VOTES",
     INITIALIZE_REQUESTED_METRICS = "INITIALIZE_REQUESTED_METRICS",
     INIITALIZE_REQUESTED_PARAMETERS = "INITIALIZE_REQUESTED_PARAMETERS",
+    INIITALIZE_REQUESTED_PARTY_MAP = "INTITIALIZE_REQUESTED_PARTY_MAP",
 }
 
 /**
  * Type containing all possible RequestedDataActions.
  */
 export type RequestedDataAction =
-    | InitializeRequestedData
     | InitializeRequestedVotes
     | InitializeRequestedMetrics
-    | InitializeRequestedParameters;
-
-/**
- * Action for initializing requested data.
- */
-export interface InitializeRequestedData {
-    type: RequestedDataActionType.INITIALIZE_REQUESTED_DATA;
-    electionType: ElectionType;
-    enableAutoSave: boolean;
-}
+    | InitializeRequestedParameters
+    | InitializeRequestedPartyMap;
 
 /**
  * Action for initializing requested votes.
@@ -53,17 +45,11 @@ export interface InitializeRequestedParameters {
 }
 
 /**
- * Action creator for initializing requested data.
- *
- * @param electionType - Election data fetched from the API.
+ * Action for initializing requested party map.
  */
-export function initializeRequestedData(electionType: ElectionType) {
-    const action: InitializeRequestedData = {
-        type: RequestedDataActionType.INITIALIZE_REQUESTED_DATA,
-        electionType,
-        enableAutoSave: true,
-    };
-    return action;
+export interface InitializeRequestedPartyMap {
+    type: RequestedDataActionType.INIITALIZE_REQUESTED_PARTY_MAP;
+    partyMap: Dictionary<string>;
 }
 
 /**
@@ -97,10 +83,23 @@ export function initializeRequestedMetrics(metrics: Metrics[]) {
  *
  * @param parameters - Parameters fetched from the API.
  */
-export function InitializeRequestedParameters(parameters: Parameters[]) {
+export function initializeRequestedParameters(parameters: Parameters[]) {
     const action: InitializeRequestedParameters = {
         type: RequestedDataActionType.INIITALIZE_REQUESTED_PARAMETERS,
         parameters,
+    };
+    return action;
+}
+
+/**
+ * Action creator for initializing requested PartyMap.
+ *
+ * @param partyMap - PartyMap fetched from the API.
+ */
+export function initializeRequestedPartyMap(partyMap: Dictionary<string>) {
+    const action: InitializeRequestedPartyMap = {
+        type: RequestedDataActionType.INIITALIZE_REQUESTED_PARTY_MAP,
+        partyMap,
     };
     return action;
 }

--- a/src/requested-data/requested-data-actions.ts
+++ b/src/requested-data/requested-data-actions.ts
@@ -48,7 +48,7 @@ export interface InitializeRequestedParameters {
  */
 export interface InitializeRequestedPartyMap {
     type: RequestedDataActionType.INIITALIZE_REQUESTED_PARTY_MAP;
-    partyMap: Map<string, string>;
+    partyMap: _.Dictionary<string>;
 }
 
 /**
@@ -95,7 +95,7 @@ export function initializeRequestedParameters(parameters: Parameters[]) {
  *
  * @param partyMap - PartyMap fetched from the API.
  */
-export function initializeRequestedPartyMap(partyMap: Map<string, string>) {
+export function initializeRequestedPartyMap(partyMap: _.Dictionary<string>) {
     const action: InitializeRequestedPartyMap = {
         type: RequestedDataActionType.INIITALIZE_REQUESTED_PARTY_MAP,
         partyMap,

--- a/src/requested-data/requested-data-actions.ts
+++ b/src/requested-data/requested-data-actions.ts
@@ -1,5 +1,4 @@
 ﻿import { Votes, Metrics, Parameters } from "./requested-data-models";
-import { Dictionary } from "../utilities/dictionary";
 
 /**
  * Enum containing all possible RequestedDataAction types.
@@ -49,7 +48,7 @@ export interface InitializeRequestedParameters {
  */
 export interface InitializeRequestedPartyMap {
     type: RequestedDataActionType.INIITALIZE_REQUESTED_PARTY_MAP;
-    partyMap: Dictionary<string>;
+    partyMap: Map<string, string>;
 }
 
 /**
@@ -96,7 +95,7 @@ export function initializeRequestedParameters(parameters: Parameters[]) {
  *
  * @param partyMap - PartyMap fetched from the API.
  */
-export function initializeRequestedPartyMap(partyMap: Dictionary<string>) {
+export function initializeRequestedPartyMap(partyMap: Map<string, string>) {
     const action: InitializeRequestedPartyMap = {
         type: RequestedDataActionType.INIITALIZE_REQUESTED_PARTY_MAP,
         partyMap,

--- a/src/requested-data/requested-data-models.ts
+++ b/src/requested-data/requested-data-models.ts
@@ -1,47 +1,6 @@
 import { Dictionary, RawDictionaryEntry } from "../utilities/dictionary";
 import { AlgorithmType } from "../computation";
 
-export interface County {
-    countyId: number;
-    name: string;
-    seats: number;
-    countryId: number;
-    electionId: number;
-    results: Result[];
-}
-
-export interface Election {
-    electionId: number;
-    year: number;
-    algorithm: number;
-    firstDivisor: number;
-    threshold: number;
-    seats: number;
-    levelingSeats: number;
-    countryId: number;
-    electionTypeId: number;
-    counties: County[];
-}
-
-export interface ElectionType {
-    countryId: number;
-    electionTypeId: number;
-    elections: Election[];
-    internationalName: string;
-}
-
-export interface Result {
-    resultId: number;
-    votes: number;
-    percentage: number;
-    electionId: number;
-    partyId: number;
-    countyId: number;
-    countyName: string;
-    partyCode: string;
-    partyName: string;
-}
-
 export interface Votes {
     party: string;
     votes: number;
@@ -90,3 +49,5 @@ export interface Parameters {
     levelingSeats: number;
     totalVotes: number;
 }
+
+export const FirstDivisor = "First Divisor";

--- a/src/requested-data/requested-data-models.ts
+++ b/src/requested-data/requested-data-models.ts
@@ -1,4 +1,4 @@
-import { Dictionary, RawDictionaryEntry } from "../utilities/dictionary";
+import { RawDictionaryEntry } from "../utilities/dictionary";
 import { AlgorithmType } from "../computation";
 
 export interface Votes {
@@ -25,7 +25,7 @@ export interface RawAlgorithm {
 
 export interface Algorithm {
     algorithm: AlgorithmType;
-    parameters: Dictionary<number>;
+    parameters: _.Dictionary<number>;
 }
 
 export interface RawParameters {

--- a/src/requested-data/requested-data-reducer.ts
+++ b/src/requested-data/requested-data-reducer.ts
@@ -3,10 +3,11 @@ import { RequestedDataState, unloadedState } from "./requested-data-state";
 
 function checkStateLoaded(state: RequestedDataState, action: RequestedDataAction): boolean {
     return (
-        (state.electionType.countryId !== -1 || action.type === RequestedDataActionType.INITIALIZE_REQUESTED_DATA) &&
         (state.metrics.length > 0 || action.type === RequestedDataActionType.INITIALIZE_REQUESTED_METRICS) &&
         (state.parameters.length > 0 || action.type === RequestedDataActionType.INIITALIZE_REQUESTED_PARAMETERS) &&
-        (state.votes.length > 0 || action.type === RequestedDataActionType.INTIIALIZE_REQUESTED_VOTES)
+        (state.votes.length > 0 || action.type === RequestedDataActionType.INTIIALIZE_REQUESTED_VOTES) &&
+        (Object.keys(state.partyMap).length > 0 ||
+            action.type === RequestedDataActionType.INIITALIZE_REQUESTED_PARTY_MAP)
     );
 }
 
@@ -22,13 +23,6 @@ export function requestedData(
     action: RequestedDataAction
 ): RequestedDataState {
     switch (action.type) {
-        case RequestedDataActionType.INITIALIZE_REQUESTED_DATA:
-            return {
-                ...state,
-                electionType: action.electionType,
-                enableAutoSave: true,
-                dataLoaded: checkStateLoaded(state, action),
-            };
         case RequestedDataActionType.INTIIALIZE_REQUESTED_VOTES:
             return {
                 ...state,
@@ -45,6 +39,12 @@ export function requestedData(
             return {
                 ...state,
                 parameters: action.parameters,
+                dataLoaded: checkStateLoaded(state, action),
+            };
+        case RequestedDataActionType.INIITALIZE_REQUESTED_PARTY_MAP:
+            return {
+                ...state,
+                partyMap: action.partyMap,
                 dataLoaded: checkStateLoaded(state, action),
             };
         default:

--- a/src/requested-data/requested-data-reducer.ts
+++ b/src/requested-data/requested-data-reducer.ts
@@ -28,24 +28,28 @@ export function requestedData(
                 ...state,
                 votes: action.votes,
                 dataLoaded: checkStateLoaded(state, action),
+                enableAutoSave: checkStateLoaded(state, action),
             };
         case RequestedDataActionType.INITIALIZE_REQUESTED_METRICS:
             return {
                 ...state,
                 metrics: action.metrics,
                 dataLoaded: checkStateLoaded(state, action),
+                enableAutoSave: checkStateLoaded(state, action),
             };
         case RequestedDataActionType.INIITALIZE_REQUESTED_PARAMETERS:
             return {
                 ...state,
                 parameters: action.parameters,
                 dataLoaded: checkStateLoaded(state, action),
+                enableAutoSave: checkStateLoaded(state, action),
             };
         case RequestedDataActionType.INIITALIZE_REQUESTED_PARTY_MAP:
             return {
                 ...state,
                 partyMap: action.partyMap,
                 dataLoaded: checkStateLoaded(state, action),
+                enableAutoSave: checkStateLoaded(state, action),
             };
         default:
             return state;

--- a/src/requested-data/requested-data-state.ts
+++ b/src/requested-data/requested-data-state.ts
@@ -1,24 +1,20 @@
-import { ElectionType, Votes, Metrics, Parameters } from "./requested-data-models";
+import { Votes, Metrics, Parameters } from "./requested-data-models";
+import { Dictionary } from "../utilities/dictionary";
 
 export interface RequestedDataState {
     dataLoaded: boolean;
     enableAutoSave: boolean;
-    electionType: ElectionType;
     votes: Votes[];
     metrics: Metrics[];
     parameters: Parameters[];
+    partyMap: Dictionary<string>;
 }
 
 export const unloadedState: RequestedDataState = {
     dataLoaded: false,
     enableAutoSave: false,
-    electionType: {
-        countryId: -1,
-        electionTypeId: -1,
-        internationalName: "UNDEFINED",
-        elections: [],
-    },
     votes: [],
     metrics: [],
     parameters: [],
+    partyMap: {},
 };

--- a/src/requested-data/requested-data-state.ts
+++ b/src/requested-data/requested-data-state.ts
@@ -1,5 +1,4 @@
 import { Votes, Metrics, Parameters } from "./requested-data-models";
-import { Dictionary } from "../utilities/dictionary";
 
 export interface RequestedDataState {
     dataLoaded: boolean;
@@ -7,7 +6,7 @@ export interface RequestedDataState {
     votes: Votes[];
     metrics: Metrics[];
     parameters: Parameters[];
-    partyMap: Dictionary<string>;
+    partyMap: Map<string, string>;
 }
 
 export const unloadedState: RequestedDataState = {
@@ -16,5 +15,5 @@ export const unloadedState: RequestedDataState = {
     votes: [],
     metrics: [],
     parameters: [],
-    partyMap: {},
+    partyMap: new Map<string, string>(),
 };

--- a/src/requested-data/requested-data-state.ts
+++ b/src/requested-data/requested-data-state.ts
@@ -6,7 +6,7 @@ export interface RequestedDataState {
     votes: Votes[];
     metrics: Metrics[];
     parameters: Parameters[];
-    partyMap: Map<string, string>;
+    partyMap: _.Dictionary<string>;
 }
 
 export const unloadedState: RequestedDataState = {
@@ -15,5 +15,5 @@ export const unloadedState: RequestedDataState = {
     votes: [],
     metrics: [],
     parameters: [],
-    partyMap: new Map<string, string>(),
+    partyMap: {},
 };

--- a/src/utilities/dictionary.ts
+++ b/src/utilities/dictionary.ts
@@ -1,15 +1,11 @@
-﻿export interface Dictionary<T> {
-    [key: string]: T;
-}
-
-export interface RawDictionaryEntry {
+﻿export interface RawDictionaryEntry {
     id: number;
     key: string;
     value: number;
 }
 
-export function copyDictionary<T>(dictionary: Dictionary<T>): Dictionary<T> {
-    const copy: Dictionary<T> = {};
+export function copyDictionary<T>(dictionary: _.Dictionary<T>): _.Dictionary<T> {
+    const copy: _.Dictionary<T> = {};
 
     for (const entry in dictionary) {
         if (dictionary.hasOwnProperty(entry)) {
@@ -20,7 +16,7 @@ export function copyDictionary<T>(dictionary: Dictionary<T>): Dictionary<T> {
     return copy;
 }
 
-export function dictionaryToArray<T>(dictionary: Dictionary<T>): T[] {
+export function dictionaryToArray<T>(dictionary: _.Dictionary<T>): T[] {
     const array: T[] = [];
 
     for (const key in dictionary) {
@@ -32,8 +28,8 @@ export function dictionaryToArray<T>(dictionary: Dictionary<T>): T[] {
     return array;
 }
 
-export function rawDictionaryToDictionary(rawDictionary: Array<RawDictionaryEntry>): Dictionary<number> {
-    const dict: Dictionary<number> = {};
+export function rawDictionaryToDictionary(rawDictionary: Array<RawDictionaryEntry>): _.Dictionary<number> {
+    const dict: _.Dictionary<number> = {};
 
     rawDictionary.forEach((entry) => (dict[entry.key] = entry.value));
 

--- a/src/utilities/map.ts
+++ b/src/utilities/map.ts
@@ -37,3 +37,14 @@ export function mapAddFromArray<T>(map: Map<string, T[]>, getKey: (value: T) => 
 
     return newMap;
 }
+
+export function createMapFromObject<T>(object: { [key: string]: T }): Map<string, T> {
+    const newMap = new Map<string, T>();
+    for (const key in object) {
+        if (Object.prototype.hasOwnProperty.call(object, key)) {
+            newMap.set(key, object[key]);
+        }
+    }
+
+    return newMap;
+}

--- a/src/utilities/number.ts
+++ b/src/utilities/number.ts
@@ -2,3 +2,7 @@ export function roundNumber(value: number, decimals: number) {
     const rounder = Math.pow(10, decimals);
     return Math.round(value * rounder) / rounder;
 }
+
+export function calculatePercent(value: number, total: number) {
+    return (value / total) * 100;
+}


### PR DESCRIPTION
# Description
This PR separates the client entirely from API v1 so it only relies on API v3.
The migration should halve the amount of data downloaded from the API.

## Issues closed
Closes #219 
