### PR TITLE
fix: do not show 0 should be ≠ 0 not > 0

### DIFF
--- a/src/Layout/Presentation/ElectionOverview/ElectionOverview.tsx
+++ b/src/Layout/Presentation/ElectionOverview/ElectionOverview.tsx
@@ -96,7 +96,7 @@ export class ElectionOverview extends React.Component<ElectionOverviewProps, {}>
         }
         const allTrueFalseOptions = [
             { value: "all", title: "Alle" },
-            { value: "true", title: "> 0" },
+            { value: "true", title: "≠ 0" },
             { value: "false", title: "= 0" },
         ];
 


### PR DESCRIPTION
# Description
The table filter options hiding rows with 0 in the column should be indicated by ≠ 0 instead of > 0, as it will still show rows with values < 0.

## Issues closed
Closes #239 
