### PR TITLE
Feature/correct typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This guide in other languages:
 An application that simulates seat distribution in elections. Current features include:
 
 -   All the Norwegian Parliamentary Elections since 1945
--   Sainte-Lagüe (modified), d'Hondt and largest fraction (Hare, Droop, Hagenbach-Bischoff) distribution methods
+-   Sainte-Laguë (modified), d'Hondt and largest fraction (Hare, Droop, Hagenbach-Bischoff) distribution methods
 -   Detailed tables describing the simulation results
 -   Parameters for adjusting how the seats are distributed
 -   Merging of counties to simulate the effect of the new Norwegian regions of 2020

--- a/README.nob.md
+++ b/README.nob.md
@@ -11,7 +11,7 @@ Denne guiden på andre språk:
 En applikasjon som simulerer mandatdistribusjon i valg. Nåværende funksjonalitet inkluderer:
 
 -   Alle stortingsvalg siden 1945
--   Fordelingsmetodene Sainte-Lagüe (modifisert), d'Hondt, største brøks metode (Hare, Droop & Hagenbach-Bischoff)
+-   Fordelingsmetodene Sainte-Laguë (modifisert), d'Hondt, største brøks metode (Hare, Droop & Hagenbach-Bischoff)
 -   Detaljerte tabeller som beskriver simulasjonsresultatene
 -   Parametere for å justere hvordan mandatene fordeles
 -   Sammenslåing av fylker for å simulere effekten av de nye regionene i 2020

--- a/src/Layout/Presentation/RemainderQuotients/RemainderQuotients.tsx
+++ b/src/Layout/Presentation/RemainderQuotients/RemainderQuotients.tsx
@@ -22,7 +22,7 @@ export interface RemainderQuotientsProps {
  *
  * @param districtResults results of a computation having been run on an
  * election
- * @returns an array of data representing the last remainder from a Sainte-Lagüe,
+ * @returns an array of data representing the last remainder from a Sainte-Laguë,
  * D'Hondt, Largest fraction (Hare) or Largest fraction (Droop) calculation in a given district for a given party,
  * and whether or not they won a levelling seat in that district-party
  */

--- a/src/Layout/Tutorial/Tutorial.tsx
+++ b/src/Layout/Tutorial/Tutorial.tsx
@@ -21,20 +21,20 @@ export class Tutorial extends React.Component<TutorialProps, {}> {
                         <b>Lavinia</b>
                         <p>
                             Lavinia er et verktøy for å vise hvordan den norske valgordningen gjør om stemmer
-                            til mandater ved stortingsvalg. Ved å justere på innstillingene for valgordningen kan du
+                            til mandater ved stortingsvalg. Ved å justere på innstillingene for valgordningen, kan du
                             se hvordan det påvirker resultatene og hvilke partier som vinner eller taper på forandringene.
                         </p>
                         <br />
                         <b>Programtips</b>
                         <p>
                             I Lavinia vil du se hjelpesymboler (<i className="fas fa-info-circle has-text-primary" />)
-                            ved de forskjellige innstillingene. Dersom du holder musepekeren over de vil du få en kort
+                            ved de forskjellige innstillingene. Dersom du holder musepekeren over dem, vil du få en kort
                             forklaring om innstillingen. Du kan klikke på symbolene for å få mer informasjon.
                         </p>
                         <br />
                         <b>Wiki</b>
                         <p>
-                            For å lese mer som Lavinia og det norske valgsystemet kan du ta en titt på wikien vår:
+                            For å lese mer som Lavinia og det norske valgsystemet, kan du ta en titt på wikien vår:
                             <a target="_blank" rel="noopener noreferrer" href={process.env.WIKI}>
                                 {" "}
                                 {process.env.WIKI}

--- a/src/Layout/Tutorial/Tutorial.tsx
+++ b/src/Layout/Tutorial/Tutorial.tsx
@@ -34,7 +34,7 @@ export class Tutorial extends React.Component<TutorialProps, {}> {
                         <br />
                         <b>Wiki</b>
                         <p>
-                            For å lese mer som Lavinia og det norske valgsystemet, kan du ta en titt på wikien vår:
+                            For å lese mer om Lavinia og det norske valgsystemet, kan du ta en titt på wikien vår:
                             <a target="_blank" rel="noopener noreferrer" href={process.env.WIKI}>
                                 {" "}
                                 {process.env.WIKI}

--- a/src/computation/logic/algorithm-utilities.ts
+++ b/src/computation/logic/algorithm-utilities.ts
@@ -550,7 +550,7 @@ export function getAlgorithmType(type: number) {
 export function getAlgorithmName(type: number) {
     switch (type) {
         case 1:
-            return "Sainte-Lagüe";
+            return "Sainte-Laguë";
         case 2:
             return "d'Hondt";
         case 3:
@@ -572,7 +572,7 @@ export function getAlgorithmName(type: number) {
 export function getAlgorithmNameFromType(type: AlgorithmType) {
     switch (type) {
         case AlgorithmType.SAINTE_LAGUE:
-            return "Sainte-Lagüe";
+            return "Sainte-Laguë";
         case AlgorithmType.D_HONDT:
             return "d'Hondt";
         case AlgorithmType.LARGEST_FRACTION_HARE:


### PR DESCRIPTION
# Description
Corrects a number of typos in the client.
Most notably: missing commas and Sainte-Lagüe -> Sainte-Laguë.

## Issues closed
Closes #268 
Closes #267 
