### PR TITLE
2.9.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,6 @@ pipeline {
         script {
           try {
             sh 'ls -1'
-            sh 'ls -1 dist'
             sh 'yarn cy:test'
           } catch (ex) {
             unstable('Some tests failed')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lavinia",
-    "version": "2.9.3",
+    "version": "2.9.4",
     "private": true,
     "description": "A seat distribution application for modern democracies",
     "main": "index.js",

--- a/src/store/version.ts
+++ b/src/store/version.ts
@@ -47,7 +47,7 @@ function clearAndSave() {
 export const currentVersion: Version = {
     major: 2,
     minor: 9,
-    patch: 3,
+    patch: 4,
 };
 
 export interface Version {


### PR DESCRIPTION
Removes a call to list the contents of the dist folder during the testing stage, as the folder does not exist yet.