### PR TITLE
fix: Rewrite rendering logic to get set of all parties across districts up front

### DIFF
--- a/src/Layout/Presentation/SeatDistribution/SeatDistribution.tsx
+++ b/src/Layout/Presentation/SeatDistribution/SeatDistribution.tsx
@@ -50,7 +50,7 @@ export class SeatDistribution extends React.Component<SeatDistributionProps, {}>
         });
 
         for (const code of sortedPartyCodes) {
-            var partyColumn = createPartyColumn(code);
+            const partyColumn = createPartyColumn(code);
             columns.push(partyColumn);
         }
 

--- a/src/Layout/Presentation/SeatDistribution/SeatDistribution.tsx
+++ b/src/Layout/Presentation/SeatDistribution/SeatDistribution.tsx
@@ -10,30 +10,48 @@ export interface SeatDistributionProps {
 
 export class SeatDistribution extends React.Component<SeatDistributionProps, {}> {
     generateColumns(): Column[] {
-        const columns: Column[] = [
-            {
-                Header: <span className="is-pulled-left"> {"Fylker"}</span> ,
-                accessor: "name",
-                width: this.props.districtWidth * 10,
-                Cell: (row) => {
-                    return <span className="is-pulled-left" >{row.value}</span>;
-                },            
-            },
-        ];
+        // Base column for district name
+        const baseColumn: Column = {
+            Header: <span className="is-pulled-left">{"Fylker"}</span>,
+            accessor: "name",
+            width: this.props.districtWidth * 10,
+            Cell: row => <span className="is-pulled-left">{row.value}</span>,
+        };
 
-        for (const districtResult of this.props.districtResults) {
-            districtResult.partyResults.sort((v, t) => v.partyCode.localeCompare(t.partyCode));
+        // Collect the union of all parties across districts
+        const partyNameByCode = new Map<string, string>();
+        const partyCodes = new Set<string>();
+
+        for (const dr of this.props.districtResults || []) {
+            if (!dr || !dr.partyResults) { continue; }
+            for (const pr of dr.partyResults) {
+                if (!pr) { continue; }
+                partyCodes.add(pr.partyCode);
+                // prefer the first encountered name for the code
+                if (!partyNameByCode.has(pr.partyCode)) {
+                    partyNameByCode.set(pr.partyCode, pr.partyName);
+                }
+            }
         }
 
-        if (this.props.districtResults.length > 0) {
-            for (let partyIndex = 0; partyIndex < this.props.districtResults[0].partyResults.length; partyIndex++) {
-                const element = this.props.districtResults[0].partyResults[partyIndex];
-                columns.push({
-                    Header:  <abbr title={element.partyName}>{element.partyCode}</abbr>,
-                    accessor: `partyResults[${partyIndex}].totalSeats`,
-                    minWidth: 50,
-                });
-            }
+        const sortedPartyCodes = Array.from(partyCodes).sort((a, b) => a.localeCompare(b));
+
+        const columns: Column[] = [baseColumn];
+
+        const createPartyColumn = (code: string): Column => ({
+            Header: <abbr title={partyNameByCode.get(code) || code}>{code}</abbr>,
+            id: code,
+            accessor: (d: DistrictResult) => {
+                const pr = d.partyResults
+                    && d.partyResults.find(p => p.partyCode === code);
+                return pr ? pr.totalSeats : 0;
+            },
+            minWidth: 50,
+        });
+
+        for (const code of sortedPartyCodes) {
+            var partyColumn = createPartyColumn(code);
+            columns.push(partyColumn);
         }
 
         return columns;

--- a/src/Layout/Presentation/SeatDistribution/SeatDistribution.tsx
+++ b/src/Layout/Presentation/SeatDistribution/SeatDistribution.tsx
@@ -15,7 +15,7 @@ export class SeatDistribution extends React.Component<SeatDistributionProps, {}>
             Header: <span className="is-pulled-left">{"Fylker"}</span>,
             accessor: "name",
             width: this.props.districtWidth * 10,
-            Cell: row => <span className="is-pulled-left">{row.value}</span>,
+            Cell: (row) => <span className="is-pulled-left">{row.value}</span>,
         };
 
         // Collect the union of all parties across districts
@@ -43,7 +43,7 @@ export class SeatDistribution extends React.Component<SeatDistributionProps, {}>
             id: code,
             accessor: (d: DistrictResult) => {
                 const pr = d.partyResults
-                    && d.partyResults.find(p => p.partyCode === code);
+                    && d.partyResults.find((p) => p.partyCode === code);
                 return pr ? pr.totalSeats : 0;
             },
             minWidth: 50,


### PR DESCRIPTION
Previously we would use a 'shortcut' which resulted in incorrect rendering and strange column errors

# Description
This pull request refactors the `generateColumns` method in `SeatDistribution.tsx` to make the seat distribution table dynamically generate party columns based on the union of all parties present in the district results, rather than relying on the first district's party list. This fixes a confusing rendering bug that resulted from relying on the first district's party list.

# Testing
Run the client locally and check that the behaviour from #315 is addressed. 
## Setup
If you need a recap since it's been a while:

Set the values for the `.env` file locally, and use something like [nvm](https://github.com/nvm-sh/nvm) to set the Node version to 12. Run `yarn install` then `yarn start`. Make sure port 3000 is free or that you manually set it to one that is.

## Expected
The 2021 election for "Fylkesfordeling av mandater" view should appear without the defects described in #314

## Issues closed
Closes #315 
