### PR TITLE
fix: Add development for PR validation

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -3,7 +3,7 @@ name: PR Validation
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [ master ]
+    branches: [ master, development ]
 
 concurrency:
   group: pr-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
# Description
This PR adds the development branch to the list of branches to run PR validations for

# Testing
When this PR is opened towards the development branch, the PR validation pipelines should run.