### PR TITLE
feat: Migrate client data loading from live API to static JSON files

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -1,3 +1,2 @@
-API_V3=https://lavinia-api-staging.azurewebsites.net/api/v3.0.0/
 SWAGGERUI=https://lavinia-api-staging.azurewebsites.net/
 WIKI=https://project-lavinia.github.io/

--- a/.env.defaults
+++ b/.env.defaults
@@ -1,2 +1,1 @@
-SWAGGERUI=https://lavinia-api-staging.azurewebsites.net/
 WIKI=https://project-lavinia.github.io/

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -26,6 +26,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
 
+      - name: Download static election data bundle
+        run: yarn download-data
+
       - name: Install dependencies
         run: yarn --frozen-lockfile
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Download static election data bundle
         run: yarn download-data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         run: yarn --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
 
       - name: Download static election data bundle
         run: yarn download-data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload election data artifact
         if: matrix.container == 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
     env:
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
       BUILD_BUILDNUMBER: ${{ github.run_id }}-${{ github.run_attempt }}
-      SWAGGERUI: https://api.lavinia.no/
       WIKI: https://wiki.lavinia.no/
     strategy:
       matrix:
@@ -104,7 +103,6 @@ jobs:
     needs: test-and-build
     if: needs.test-and-build.result == 'success'
     env:
-      SWAGGERUI: https://api.lavinia.no/
       WIKI: https://wiki.lavinia.no/
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,9 @@ jobs:
     env:
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
       BUILD_BUILDNUMBER: ${{ github.run_id }}-${{ github.run_attempt }}
-      API_V3: https://api.lavinia.no/api/v3.0.0/
       SWAGGERUI: https://api.lavinia.no/
       WIKI: https://wiki.lavinia.no/
+      API_DATA_REPOSITORY: Project-Lavinia/Lavinia-api
     strategy:
       matrix:
         container: [1, 2, 3]
@@ -39,6 +39,69 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
+
+      - name: Resolve app/data versions from package.json
+        run: |
+          APP_VERSION=$(node -p "require('./package.json').version")
+          API_DATA_VERSION=$(node -p "require('./package.json').dataVersion")
+
+          if [ -z "$APP_VERSION" ]; then
+            echo "Missing package.json field: version."
+            exit 1
+          fi
+
+          if [ -z "$API_DATA_VERSION" ]; then
+            echo "Missing package.json field: dataVersion."
+            exit 1
+          fi
+
+          if [ "$APP_VERSION" != "$GITHUB_REF_NAME" ]; then
+            echo "Tag/version mismatch: package.json version '$APP_VERSION' does not match release tag '$GITHUB_REF_NAME'."
+            exit 1
+          fi
+
+          echo "Using package.json app version: $APP_VERSION"
+          echo "Using package.json data version: $API_DATA_VERSION"
+          echo "API_DATA_VERSION=$API_DATA_VERSION" >> "$GITHUB_ENV"
+          echo "DATA_VERSION=$API_DATA_VERSION" >> "$GITHUB_ENV"
+          echo "APP_VERSION=$APP_VERSION" >> "$GITHUB_ENV"
+
+      - name: Download static election data bundle
+        run: |
+          RELEASE_METADATA_URL="https://api.github.com/repos/$API_DATA_REPOSITORY/releases/tags/$API_DATA_VERSION"
+          if ! curl -fsSL -H "Accept: application/vnd.github+json" "$RELEASE_METADATA_URL" -o /tmp/api-release.json; then
+            echo "API release '$API_DATA_VERSION' was not found in $API_DATA_REPOSITORY."
+            exit 1
+          fi
+
+          DATA_ASSET=$(jq 'first(.assets[] | select(.name == "election-data.zip"))' /tmp/api-release.json)
+          if [ -z "$DATA_ASSET" ] || [ "$DATA_ASSET" = "null" ]; then
+            echo "Release '$API_DATA_VERSION' exists, but election-data.zip asset is missing."
+            exit 1
+          fi
+
+          DATA_ASSET_URL=$(echo "$DATA_ASSET" | jq -r '.browser_download_url')
+          EXPECTED_SHA=$(echo "$DATA_ASSET" | jq -r '.digest' | sed 's/^sha256://')
+          if [ -z "$EXPECTED_SHA" ] || [ "$EXPECTED_SHA" = "null" ]; then
+            echo "No SHA-256 digest on election-data.zip asset in release '$API_DATA_VERSION'."
+            exit 1
+          fi
+
+          curl -fsSL -o /tmp/election-data.zip "$DATA_ASSET_URL"
+          echo "$EXPECTED_SHA  /tmp/election-data.zip" | sha256sum -c -
+
+          rm -rf src/assets/election-data
+          mkdir -p src/assets/election-data
+          unzip -o /tmp/election-data.zip -d src/assets/election-data
+          test -f src/assets/election-data/manifest.json
+          jq -e --arg expectedVersion "$API_DATA_VERSION" '.dataVersion == $expectedVersion' src/assets/election-data/manifest.json
+
+      - name: Upload election data artifact
+        if: matrix.container == 1
+        uses: actions/upload-artifact@v4
+        with:
+          name: election-data
+          path: src/assets/election-data/
 
       - name: Install dependencies
         run: yarn --frozen-lockfile
@@ -72,7 +135,6 @@ jobs:
     needs: test-and-build
     if: needs.test-and-build.result == 'success'
     env:
-      API_V3: https://api.lavinia.no/api/v3.0.0/
       SWAGGERUI: https://api.lavinia.no/
       WIKI: https://wiki.lavinia.no/
     steps:
@@ -84,6 +146,37 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
+
+      - name: Resolve app/data versions from package.json
+        run: |
+          APP_VERSION=$(node -p "require('./package.json').version")
+          API_DATA_VERSION=$(node -p "require('./package.json').dataVersion")
+
+          if [ -z "$APP_VERSION" ]; then
+            echo "Missing package.json field: version."
+            exit 1
+          fi
+
+          if [ -z "$API_DATA_VERSION" ]; then
+            echo "Missing package.json field: dataVersion."
+            exit 1
+          fi
+
+          if [ "$APP_VERSION" != "$GITHUB_REF_NAME" ]; then
+            echo "Tag/version mismatch: package.json version '$APP_VERSION' does not match release tag '$GITHUB_REF_NAME'."
+            exit 1
+          fi
+
+          echo "Using package.json app version: $APP_VERSION"
+          echo "Using package.json data version: $API_DATA_VERSION"
+          echo "DATA_VERSION=$API_DATA_VERSION" >> "$GITHUB_ENV"
+          echo "APP_VERSION=$APP_VERSION" >> "$GITHUB_ENV"
+
+      - name: Download election data artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: election-data
+          path: src/assets/election-data/
 
       - name: Install dependencies
         run: yarn --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
       BUILD_BUILDNUMBER: ${{ github.run_id }}-${{ github.run_attempt }}
       SWAGGERUI: https://api.lavinia.no/
       WIKI: https://wiki.lavinia.no/
-      API_DATA_REPOSITORY: Project-Lavinia/Lavinia-api
     strategy:
       matrix:
         container: [1, 2, 3]
@@ -62,39 +61,9 @@ jobs:
 
           echo "Using package.json app version: $APP_VERSION"
           echo "Using package.json data version: $API_DATA_VERSION"
-          echo "API_DATA_VERSION=$API_DATA_VERSION" >> "$GITHUB_ENV"
-          echo "DATA_VERSION=$API_DATA_VERSION" >> "$GITHUB_ENV"
-          echo "APP_VERSION=$APP_VERSION" >> "$GITHUB_ENV"
 
       - name: Download static election data bundle
-        run: |
-          RELEASE_METADATA_URL="https://api.github.com/repos/$API_DATA_REPOSITORY/releases/tags/$API_DATA_VERSION"
-          if ! curl -fsSL -H "Accept: application/vnd.github+json" "$RELEASE_METADATA_URL" -o /tmp/api-release.json; then
-            echo "API release '$API_DATA_VERSION' was not found in $API_DATA_REPOSITORY."
-            exit 1
-          fi
-
-          DATA_ASSET=$(jq 'first(.assets[] | select(.name == "election-data.zip"))' /tmp/api-release.json)
-          if [ -z "$DATA_ASSET" ] || [ "$DATA_ASSET" = "null" ]; then
-            echo "Release '$API_DATA_VERSION' exists, but election-data.zip asset is missing."
-            exit 1
-          fi
-
-          DATA_ASSET_URL=$(echo "$DATA_ASSET" | jq -r '.browser_download_url')
-          EXPECTED_SHA=$(echo "$DATA_ASSET" | jq -r '.digest' | sed 's/^sha256://')
-          if [ -z "$EXPECTED_SHA" ] || [ "$EXPECTED_SHA" = "null" ]; then
-            echo "No SHA-256 digest on election-data.zip asset in release '$API_DATA_VERSION'."
-            exit 1
-          fi
-
-          curl -fsSL -o /tmp/election-data.zip "$DATA_ASSET_URL"
-          echo "$EXPECTED_SHA  /tmp/election-data.zip" | sha256sum -c -
-
-          rm -rf src/assets/election-data
-          mkdir -p src/assets/election-data
-          unzip -o /tmp/election-data.zip -d src/assets/election-data
-          test -f src/assets/election-data/manifest.json
-          jq -e --arg expectedVersion "$API_DATA_VERSION" '.dataVersion == $expectedVersion' src/assets/election-data/manifest.json
+        run: yarn download-data
 
       - name: Upload election data artifact
         if: matrix.container == 1
@@ -169,8 +138,6 @@ jobs:
 
           echo "Using package.json app version: $APP_VERSION"
           echo "Using package.json data version: $API_DATA_VERSION"
-          echo "DATA_VERSION=$API_DATA_VERSION" >> "$GITHUB_ENV"
-          echo "APP_VERSION=$APP_VERSION" >> "$GITHUB_ENV"
 
       - name: Download election data artifact
         uses: actions/download-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 *.log*
 build
 dist
+src/assets/election-data
 app.yaml
 .gcloudignore
 cypress/videos

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Read more about Lavinia and the Norwegian election system in our [wiki](https://
 1. Clone the repository to your preferred folder
 2. Open your favourite terminal and navigate to aforementioned folder
 3. Type `yarn` <kbd>Enter</kbd> and wait patiently for the packages to be installed
-4. Type `yarn start` <kbd>Enter</kbd>
+4. Type `yarn download-data` <kbd>Enter</kbd> and wait patiently for the election data to be downloaded
+5. Type `yarn start` <kbd>Enter</kbd>
 
-After step 4. your default browser should have opened up, running a development server locally on your machine. In most terminals, hit <kbd>Ctrl</kbd>+<kbd>c</kbd> with your terminal focused to close the application.
+After step 5. your default browser should have opened up, running a development server locally on your machine. In most terminals, hit <kbd>Ctrl</kbd>+<kbd>c</kbd> with your terminal focused to close the application.

--- a/README.nob.md
+++ b/README.nob.md
@@ -30,6 +30,7 @@ Les mer om Lavinia og det norske valgsystemet i vår [wiki](https://project-lavi
 1. Klon repositoriet ned til din foretrukne mappe
 2. Åpne favoritt-terminalen din og naviger til den tidligere nevnte mappen
 3. Skriv inn `yarn` <kbd>Enter</kbd> og vent tålmodig på at de nødvendige pakkene installeres
-4. Skriv inn `yarn start` <kbd>Enter</kbd>
+4. Skriv inn `yarn download-data` <kbd>Enter</kbd> og vent tålmodig på at valgdatasettet lastes ned
+5. Skriv inn `yarn start` <kbd>Enter</kbd>
 
-Etter steg 4. burde din standard-nettleser åpne seg med applikasjonen i et vindu eller en fane. I de fleste terminaler stopper du applikasjonen ved å fokusere terminalen og trykke <kbd>Ctrl</kbd>+<kbd>c</kbd>
+Etter steg 5. burde din standard-nettleser åpne seg med applikasjonen i et vindu eller en fane. I de fleste terminaler stopper du applikasjonen ved å fokusere terminalen og trykke <kbd>Ctrl</kbd>+<kbd>c</kbd>

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "bulma-switch": "^2.0.0",
         "bulma-tooltip": "^3.0.2",
         "clean-webpack-plugin": "^4.0.0",
-        "copy-webpack-plugin": "^14.0.0",
+        "copy-webpack-plugin": "14.0.0",
         "css-loader": "^3.5.3",
         "cypress": "^4.8.0",
         "dotenv-webpack": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "lavinia",
     "version": "2.9.9",
+    "dataVersion": "3.5.0",
     "private": true,
     "description": "A seat distribution application for modern democracies",
     "main": "index.js",
@@ -17,7 +18,8 @@
         "cy:run": "cypress run --reporter junit --reporter-options \"mochaFile=results/cypress-[hash].xml,toConsole=true\"",
         "cy:test": "start-server-and-test start:production 3000 cy:run",
         "cy:ci:run": "cypress run --record --key $CYPRESS_RECORD_KEY --parallel --ci-build-id $BUILD_BUILDNUMBER",
-        "cy:ci:test": "start-server-and-test start 3000 cy:ci:run"
+        "cy:ci:test": "start-server-and-test start 3000 cy:ci:run",
+        "download-data": "node scripts/download-data.js"
     },
     "license": "MIT",
     "devDependencies": {
@@ -36,6 +38,7 @@
         "bulma-switch": "^2.0.0",
         "bulma-tooltip": "^3.0.2",
         "clean-webpack-plugin": "^4.0.0",
+        "copy-webpack-plugin": "^14.0.0",
         "css-loader": "^3.5.3",
         "cypress": "^4.8.0",
         "dotenv-webpack": "^1.8.0",
@@ -43,10 +46,10 @@
         "html-webpack-plugin": "^5.6.0",
         "husky": "^4.2.5",
         "mini-css-extract-plugin": "^2.9.0",
-        "sass": "^1.83.0",
         "prettier": "^2.0.5",
         "pretty-quick": "^2.0.1",
         "react-hot-loader": "^4.12.21",
+        "sass": "^1.83.0",
         "sass-loader": "^8.0.2",
         "start-server-and-test": "^1.11.0",
         "style-loader": "^1.2.1",

--- a/scripts/download-data.js
+++ b/scripts/download-data.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+/* eslint-disable no-console */
+/* eslint-disable complexity */
 // Downloads the pinned election-data bundle from the Lavinia-api GitHub release
 // and extracts it to src/assets/election-data/.
 //
@@ -16,20 +18,22 @@ const API_REPO = "Project-Lavinia/Lavinia-api";
 const OUT_DIR = path.join(__dirname, "../src/assets/election-data");
 const TMP_ZIP = "/tmp/lavinia-election-data.zip";
 
-function computeSha256(filePath) {
+function computeSha256() {
     return new Promise((resolve, reject) => {
         const hash = crypto.createHash("sha256");
-        const stream = fs.createReadStream(filePath);
+        const stream = fs.createReadStream(TMP_ZIP);
         stream.on("data", (chunk) => hash.update(chunk));
         stream.on("end", () => resolve(hash.digest("hex")));
         stream.on("error", reject);
     });
 }
 
-async function download(url, dest) {
+async function download(url) {
     const res = await fetch(url, { headers: { "User-Agent": "lavinia-client" } });
-    if (!res.ok) throw new Error(`Failed to download ${url}: HTTP ${res.status}`);
-    await pipeline(Readable.fromWeb(res.body), fs.createWriteStream(dest));
+    if (!res.ok) {
+        throw new Error(`Failed to download ${url}: HTTP ${res.status}`);
+    }
+    await pipeline(Readable.fromWeb(res.body), fs.createWriteStream(TMP_ZIP));
 }
 
 async function main() {
@@ -64,10 +68,10 @@ async function main() {
     const expectedSha = digest.slice("sha256:".length);
 
     console.log(`Downloading ${asset.browser_download_url}...`);
-    await download(asset.browser_download_url, TMP_ZIP);
+    await download(asset.browser_download_url);
 
     console.log("Verifying checksum...");
-    const actualSha = await computeSha256(TMP_ZIP);
+    const actualSha = await computeSha256();
     if (actualSha !== expectedSha) {
         console.error(`Checksum mismatch: expected ${expectedSha}, got ${actualSha}`);
         process.exit(1);

--- a/scripts/download-data.js
+++ b/scripts/download-data.js
@@ -44,9 +44,11 @@ async function main() {
 
     console.log(`Fetching release metadata for ${API_REPO}@${dataVersion}...`);
     const metaUrl = `https://api.github.com/repos/${API_REPO}/releases/tags/${dataVersion}`;
-    const metaRes = await fetch(metaUrl, {
-        headers: { "User-Agent": "lavinia-client", Accept: "application/vnd.github+json" },
-    });
+    const metaHeaders = { "User-Agent": "lavinia-client", Accept: "application/vnd.github+json" };
+    if (process.env.GITHUB_TOKEN) {
+        metaHeaders["Authorization"] = `Bearer ${process.env.GITHUB_TOKEN}`;
+    }
+    const metaRes = await fetch(metaUrl, { headers: metaHeaders });
 
     if (!metaRes.ok) {
         console.error(`Release ${dataVersion} not found in ${API_REPO} (HTTP ${metaRes.status})`);

--- a/scripts/download-data.js
+++ b/scripts/download-data.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
-/* eslint-disable no-console */
-/* eslint-disable complexity */
+/* eslint-disable no-console, complexity, security/detect-non-literal-fs-filename */
 // Downloads the pinned election-data bundle from the Lavinia-api GitHub release
 // and extracts it to src/assets/election-data/.
 //
@@ -11,12 +10,13 @@ const fs = require("fs");
 const path = require("path");
 const { pipeline } = require("stream/promises");
 const { Readable } = require("stream");
-const { execSync } = require("child_process");
+const { execFileSync } = require("child_process");
+const os = require("os");
 
 const { dataVersion } = require("../package.json");
 const API_REPO = "Project-Lavinia/Lavinia-api";
 const OUT_DIR = path.join(__dirname, "../src/assets/election-data");
-const TMP_ZIP = "/tmp/lavinia-election-data.zip";
+const TMP_ZIP = path.join(os.tmpdir(), "lavinia-election-data.zip");
 
 function computeSha256() {
     return new Promise((resolve, reject) => {
@@ -80,7 +80,7 @@ async function main() {
 
     fs.rmSync(OUT_DIR, { recursive: true, force: true });
     fs.mkdirSync(OUT_DIR, { recursive: true });
-    execSync(`unzip -o ${TMP_ZIP} -d ${OUT_DIR}`, { stdio: "inherit" });
+    execFileSync("unzip", ["-o", TMP_ZIP, "-d", OUT_DIR], { stdio: "inherit" });
     fs.rmSync(TMP_ZIP, { force: true });
 
     const manifest = JSON.parse(fs.readFileSync(path.join(OUT_DIR, "manifest.json"), "utf8"));

--- a/scripts/download-data.js
+++ b/scripts/download-data.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// Downloads the pinned election-data bundle from the Lavinia-api GitHub release
+// and extracts it to src/assets/election-data/.
+//
+// Run via: yarn download-data
+
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+const { pipeline } = require("stream/promises");
+const { Readable } = require("stream");
+const { execSync } = require("child_process");
+
+const { dataVersion } = require("../package.json");
+const API_REPO = "Project-Lavinia/Lavinia-api";
+const OUT_DIR = path.join(__dirname, "../src/assets/election-data");
+const TMP_ZIP = "/tmp/lavinia-election-data.zip";
+
+function computeSha256(filePath) {
+    return new Promise((resolve, reject) => {
+        const hash = crypto.createHash("sha256");
+        const stream = fs.createReadStream(filePath);
+        stream.on("data", (chunk) => hash.update(chunk));
+        stream.on("end", () => resolve(hash.digest("hex")));
+        stream.on("error", reject);
+    });
+}
+
+async function download(url, dest) {
+    const res = await fetch(url, { headers: { "User-Agent": "lavinia-client" } });
+    if (!res.ok) throw new Error(`Failed to download ${url}: HTTP ${res.status}`);
+    await pipeline(Readable.fromWeb(res.body), fs.createWriteStream(dest));
+}
+
+async function main() {
+    if (!dataVersion) {
+        console.error("Missing dataVersion in package.json");
+        process.exit(1);
+    }
+
+    console.log(`Fetching release metadata for ${API_REPO}@${dataVersion}...`);
+    const metaUrl = `https://api.github.com/repos/${API_REPO}/releases/tags/${dataVersion}`;
+    const metaRes = await fetch(metaUrl, {
+        headers: { "User-Agent": "lavinia-client", Accept: "application/vnd.github+json" },
+    });
+
+    if (!metaRes.ok) {
+        console.error(`Release ${dataVersion} not found in ${API_REPO} (HTTP ${metaRes.status})`);
+        process.exit(1);
+    }
+
+    const release = await metaRes.json();
+    const asset = release.assets && release.assets.find((a) => a.name === "election-data.zip");
+    if (!asset) {
+        console.error(`election-data.zip asset missing from release ${dataVersion}`);
+        process.exit(1);
+    }
+
+    const digest = asset.digest;
+    if (!digest || !digest.startsWith("sha256:")) {
+        console.error(`No SHA-256 digest on election-data.zip asset in release ${dataVersion}`);
+        process.exit(1);
+    }
+    const expectedSha = digest.slice("sha256:".length);
+
+    console.log(`Downloading ${asset.browser_download_url}...`);
+    await download(asset.browser_download_url, TMP_ZIP);
+
+    console.log("Verifying checksum...");
+    const actualSha = await computeSha256(TMP_ZIP);
+    if (actualSha !== expectedSha) {
+        console.error(`Checksum mismatch: expected ${expectedSha}, got ${actualSha}`);
+        process.exit(1);
+    }
+    console.log(`Checksum verified: ${actualSha}`);
+
+    fs.rmSync(OUT_DIR, { recursive: true, force: true });
+    fs.mkdirSync(OUT_DIR, { recursive: true });
+    execSync(`unzip -o ${TMP_ZIP} -d ${OUT_DIR}`, { stdio: "inherit" });
+    fs.rmSync(TMP_ZIP, { force: true });
+
+    const manifest = JSON.parse(fs.readFileSync(path.join(OUT_DIR, "manifest.json"), "utf8"));
+    if (manifest.dataVersion !== dataVersion) {
+        console.error(`Manifest version mismatch: expected ${dataVersion}, got ${manifest.dataVersion}`);
+        process.exit(1);
+    }
+
+    console.log(`Election data ${manifest.dataVersion} extracted to ${OUT_DIR}`);
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/src/Layout/ConnectedLayout.tsx
+++ b/src/Layout/ConnectedLayout.tsx
@@ -27,13 +27,13 @@ const mapDispatchToProps = (
     dispatch: any
 ): Pick<LayoutProps, "initializeState" | "toggleHamburger" | "clearState"> => ({
     initializeState: async () => {
-        const votesUri = process.env.API_V3 + "votes?partyCode=ALL&district=ALL";
-        const metricsUri = process.env.API_V3 + "metrics?district=ALL";
-        const parametersUri = process.env.API_V3 + "parameters";
-        const yearsUri = process.env.API_V3 + "years";
-        const partyMapUri = process.env.API_V3 + "parties";
+        const votesUri = "/assets/election-data/votes.json";
+        const metricsUri = "/assets/election-data/metrics.json";
+        const parametersUri = "/assets/election-data/parameters.json";
+        const yearsUri = "/assets/election-data/years.json";
+        const partyMapUri = "/assets/election-data/parties.json";
 
-        if (stateIsInvalid()) {
+        if (stateIsInvalid(process.env.APP_VERSION, process.env.DATA_VERSION)) {
             let votes: Votes[] = [];
             let metrics: Metrics[] = [];
             let rawParameters: RawParameters[] = [];

--- a/src/Layout/Navigation/Navigation.tsx
+++ b/src/Layout/Navigation/Navigation.tsx
@@ -12,7 +12,7 @@ export class Navigation extends React.Component<NavigationProps> {
     };
     public render() {
         const wikiUrl = process.env.WIKI;
-        const swaggerUiUrl = process.env.SWAGGERUI;
+        const dataReleaseUrl = `https://github.com/Project-Lavinia/Lavinia-api/releases/tag/${process.env.DATA_VERSION}`;
         const style = {
             menuButton: "navbar-burger burger",
             menu: "navbar-menu",
@@ -59,11 +59,11 @@ export class Navigation extends React.Component<NavigationProps> {
                             <div className="navbar-dropdown">
                                 <a
                                     target="_blank"
-                                    href={swaggerUiUrl}
+                                    href={dataReleaseUrl}
                                     rel="noopener noreferrer"
                                     className="navbar-item"
                                 >
-                                    API
+                                    Valgdata
                                 </a>
                                 <a
                                     className="navbar-item"

--- a/src/store/local-storage.ts
+++ b/src/store/local-storage.ts
@@ -64,3 +64,29 @@ export function saveVersion(version: Version) {
         console.error(err);
     }
 }
+
+/**
+ * Loads the persisted data version from localStorage.
+ *
+ * @returns data version if present, else undefined.
+ */
+export function loadDataVersion() {
+    const dataVersion = localStorage.getItem("dataVersion");
+    if (dataVersion == null) {
+        return undefined;
+    }
+    return dataVersion;
+}
+
+/**
+ * Saves the data version to localStorage.
+ *
+ * @param dataVersion data version to save
+ */
+export function saveDataVersion(dataVersion: string) {
+    try {
+        localStorage.setItem("dataVersion", dataVersion);
+    } catch (err) {
+        console.error(err);
+    }
+}

--- a/src/store/local-storage.ts
+++ b/src/store/local-storage.ts
@@ -71,11 +71,16 @@ export function saveVersion(version: Version) {
  * @returns data version if present, else undefined.
  */
 export function loadDataVersion() {
-    const dataVersion = localStorage.getItem("dataVersion");
-    if (dataVersion == null) {
+    try {
+        const dataVersion = localStorage.getItem("dataVersion");
+        if (dataVersion == null) {
+            return undefined;
+        }
+        return dataVersion;
+    } catch (err) {
+        console.error(err);
         return undefined;
     }
-    return dataVersion;
 }
 
 /**

--- a/src/store/version.ts
+++ b/src/store/version.ts
@@ -1,23 +1,54 @@
-import { loadVersion, saveVersion, loadState } from "./local-storage";
+import { loadVersion, saveVersion, loadState, loadDataVersion, saveDataVersion } from "./local-storage";
 
 /**
  * Simple version validator.
  *
- * @param localVersion - version stored in localStorage.
- * @param appVersion - version from the application.
+ * @param appVersion - expected app version from build metadata.
+ * @param dataVersion - expected data version from build metadata.
  */
-export function stateIsInvalid() {
+export function stateIsInvalid(appVersion?: string, dataVersion?: string) {
+    const expectedVersion = resolveExpectedVersion(appVersion);
+    const expectedDataVersion = resolveExpectedDataVersion(dataVersion);
+    const localDataVersion = loadDataVersion();
     const localVersion = loadVersion();
+
+    if (localDataVersion !== expectedDataVersion) {
+        clearAndSave(expectedVersion, expectedDataVersion);
+        return true;
+    }
+
     if (localVersion) {
-        if (isIncompatibleVersion(localVersion) || !loadState()) {
-            clearAndSave();
+        if (isIncompatibleVersion(localVersion, expectedVersion) || !loadState()) {
+            clearAndSave(expectedVersion, expectedDataVersion);
             return true;
         }
     } else {
-        clearAndSave();
+        clearAndSave(expectedVersion, expectedDataVersion);
         return true;
     }
     return false;
+}
+
+function resolveExpectedVersion(rawVersion?: string): Version {
+    if (rawVersion == null || rawVersion.trim().length === 0) {
+        throw new TypeError("APP_VERSION is missing. Build configuration must inject APP_VERSION from package.json metadata.");
+    }
+
+    const [major, minor, patch] = rawVersion.split(".").map(Number);
+
+    if (!Number.isFinite(major) || !Number.isFinite(minor) || !Number.isFinite(patch)) {
+        throw new TypeError(`APP_VERSION is malformed: '${rawVersion}'. Expected semantic version format like '2.9.9'.`);
+    }
+
+    return { major, minor, patch };
+}
+
+function resolveExpectedDataVersion(dataVersion?: string): string {
+    if (dataVersion == null || dataVersion.trim().length === 0) {
+        throw new TypeError("DATA_VERSION is missing. Build configuration must inject DATA_VERSION from package.json metadata.");
+    }
+
+    return dataVersion;
 }
 
 /**
@@ -25,30 +56,18 @@ export function stateIsInvalid() {
  *
  * @param version version to check against current version
  */
-function isIncompatibleVersion(version: Version) {
-    return version.major !== currentVersion.major || version.minor !== currentVersion.minor;
+function isIncompatibleVersion(version: Version, expectedVersion: Version) {
+    return version.major !== expectedVersion.major || version.minor !== expectedVersion.minor;
 }
 
 /**
  * Clears the localStorage, saves the current version, then returns false.
  */
-function clearAndSave() {
+function clearAndSave(version: Version, dataVersion: string) {
     localStorage.clear();
-    saveVersion(currentVersion);
+    saveVersion(version);
+    saveDataVersion(dataVersion);
 }
-
-/**
- * The current version of the application.
- *
- * NB: This MUST be updated with any breaking state change!
- *
- * TODO: Configure this to be grabbed from package.json
- */
-export const currentVersion: Version = {
-    major: 2,
-    minor: 9,
-    patch: 9,
-};
 
 export interface Version {
     /**

--- a/src/store/version.ts
+++ b/src/store/version.ts
@@ -19,8 +19,8 @@ export interface Version {
     patch: number;
 }
 
-function isValidSemver(major: number, minor: number, patch: number): boolean {
-    return Number.isFinite(major) && Number.isFinite(minor) && Number.isFinite(patch);
+function isValidSemver(major: number, minor: number, patch: number, partCount: number): boolean {
+    return partCount === 3 && Number.isFinite(major) && Number.isFinite(minor) && Number.isFinite(patch);
 }
 
 function resolveExpectedVersion(rawVersion?: string): Version {
@@ -28,9 +28,10 @@ function resolveExpectedVersion(rawVersion?: string): Version {
         throw new TypeError("APP_VERSION is missing. Build configuration must inject APP_VERSION from package.json metadata.");
     }
 
-    const [major, minor, patch] = rawVersion.split(".").map(Number);
+    const parts = rawVersion.split(".");
+    const [major, minor, patch] = parts.map(Number);
 
-    if (!isValidSemver(major, minor, patch)) {
+    if (!isValidSemver(major, minor, patch, parts.length)) {
         throw new TypeError(`APP_VERSION is malformed: '${rawVersion}'. Expected semantic version format like '2.9.9'.`);
     }
 
@@ -50,7 +51,11 @@ function isIncompatibleVersion(version: Version, expectedVersion: Version) {
 }
 
 function clearAndSave(version: Version, dataVersion: string) {
-    localStorage.clear();
+    try {
+        localStorage.clear();
+    } catch (err) {
+        console.error(err);
+    }
     saveVersion(version);
     saveDataVersion(dataVersion);
 }

--- a/src/store/version.ts
+++ b/src/store/version.ts
@@ -1,74 +1,5 @@
 import { loadVersion, saveVersion, loadState, loadDataVersion, saveDataVersion } from "./local-storage";
 
-/**
- * Simple version validator.
- *
- * @param appVersion - expected app version from build metadata.
- * @param dataVersion - expected data version from build metadata.
- */
-export function stateIsInvalid(appVersion?: string, dataVersion?: string) {
-    const expectedVersion = resolveExpectedVersion(appVersion);
-    const expectedDataVersion = resolveExpectedDataVersion(dataVersion);
-    const localDataVersion = loadDataVersion();
-    const localVersion = loadVersion();
-
-    if (localDataVersion !== expectedDataVersion) {
-        clearAndSave(expectedVersion, expectedDataVersion);
-        return true;
-    }
-
-    if (localVersion) {
-        if (isIncompatibleVersion(localVersion, expectedVersion) || !loadState()) {
-            clearAndSave(expectedVersion, expectedDataVersion);
-            return true;
-        }
-    } else {
-        clearAndSave(expectedVersion, expectedDataVersion);
-        return true;
-    }
-    return false;
-}
-
-function resolveExpectedVersion(rawVersion?: string): Version {
-    if (rawVersion == null || rawVersion.trim().length === 0) {
-        throw new TypeError("APP_VERSION is missing. Build configuration must inject APP_VERSION from package.json metadata.");
-    }
-
-    const [major, minor, patch] = rawVersion.split(".").map(Number);
-
-    if (!Number.isFinite(major) || !Number.isFinite(minor) || !Number.isFinite(patch)) {
-        throw new TypeError(`APP_VERSION is malformed: '${rawVersion}'. Expected semantic version format like '2.9.9'.`);
-    }
-
-    return { major, minor, patch };
-}
-
-function resolveExpectedDataVersion(dataVersion?: string): string {
-    if (dataVersion == null || dataVersion.trim().length === 0) {
-        throw new TypeError("DATA_VERSION is missing. Build configuration must inject DATA_VERSION from package.json metadata.");
-    }
-
-    return dataVersion;
-}
-
-/**
- * Checks whether the version passed in is compatible with the current version.
- *
- * @param version version to check against current version
- */
-function isIncompatibleVersion(version: Version, expectedVersion: Version) {
-    return version.major !== expectedVersion.major || version.minor !== expectedVersion.minor;
-}
-
-/**
- * Clears the localStorage, saves the current version, then returns false.
- */
-function clearAndSave(version: Version, dataVersion: string) {
-    localStorage.clear();
-    saveVersion(version);
-    saveDataVersion(dataVersion);
-}
-
 export interface Version {
     /**
      * Identifies which version of the application (model/API) was used. Used
@@ -86,4 +17,65 @@ export interface Version {
      * this field is only used for debugging, as breaking
      */
     patch: number;
+}
+
+function isValidSemver(major: number, minor: number, patch: number): boolean {
+    return Number.isFinite(major) && Number.isFinite(minor) && Number.isFinite(patch);
+}
+
+function resolveExpectedVersion(rawVersion?: string): Version {
+    if (rawVersion == null || rawVersion.trim().length === 0) {
+        throw new TypeError("APP_VERSION is missing. Build configuration must inject APP_VERSION from package.json metadata.");
+    }
+
+    const [major, minor, patch] = rawVersion.split(".").map(Number);
+
+    if (!isValidSemver(major, minor, patch)) {
+        throw new TypeError(`APP_VERSION is malformed: '${rawVersion}'. Expected semantic version format like '2.9.9'.`);
+    }
+
+    return { major, minor, patch };
+}
+
+function resolveExpectedDataVersion(dataVersion?: string): string {
+    if (dataVersion == null || dataVersion.trim().length === 0) {
+        throw new TypeError("DATA_VERSION is missing. Build configuration must inject DATA_VERSION from package.json metadata.");
+    }
+
+    return dataVersion;
+}
+
+function isIncompatibleVersion(version: Version, expectedVersion: Version) {
+    return version.major !== expectedVersion.major || version.minor !== expectedVersion.minor;
+}
+
+function clearAndSave(version: Version, dataVersion: string) {
+    localStorage.clear();
+    saveVersion(version);
+    saveDataVersion(dataVersion);
+}
+
+function localStateMatchesExpected(expectedVersion: Version, expectedDataVersion: string): boolean {
+    const localVersion = loadVersion();
+    return loadDataVersion() === expectedDataVersion
+        && !!localVersion
+        && !isIncompatibleVersion(localVersion, expectedVersion)
+        && !!loadState();
+}
+
+/**
+ * Simple version validator.
+ *
+ * @param appVersion - expected app version from build metadata.
+ * @param dataVersion - expected data version from build metadata.
+ */
+export function stateIsInvalid(appVersion?: string, dataVersion?: string) {
+    const expectedVersion = resolveExpectedVersion(appVersion);
+    const expectedDataVersion = resolveExpectedDataVersion(dataVersion);
+
+    if (localStateMatchesExpected(expectedVersion, expectedDataVersion)) {
+        return false;
+    }
+    clearAndSave(expectedVersion, expectedDataVersion);
+    return true;
 }

--- a/tslint.json
+++ b/tslint.json
@@ -10,6 +10,7 @@
         "array-type": false,
         "curly": true,
         "no-console": false,
+        "no-use-before-declare": false,
         "no-shadowed-variable": false,
         "unified-signatures": true,
         "radix": false,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,14 +1,27 @@
 var path = require("path");
+var webpack = require("webpack");
+var packageJson = require("./package.json");
 
 // variables
 var sourcePath = path.join(__dirname, "./src");
 var outPath = path.join(__dirname, "./dist");
+var appVersion = packageJson.version;
+var dataVersion = packageJson.dataVersion;
+
+if (!appVersion) {
+    throw new TypeError("Missing package.json field: version");
+}
+
+if (!dataVersion) {
+    throw new TypeError("Missing package.json field: dataVersion");
+}
 
 // plugins
 var HtmlWebpackPlugin = require("html-webpack-plugin");
 var MiniCssExtractPlugin = require("mini-css-extract-plugin");
 var { CleanWebpackPlugin } = require("clean-webpack-plugin");
 var DotenvWebpackPlugin = require("dotenv-webpack");
+var CopyWebpackPlugin = require("copy-webpack-plugin");
 
 module.exports = (env, argv) => {
     const isProduction = argv.mode === "production";
@@ -85,6 +98,10 @@ module.exports = (env, argv) => {
                 defaults: !isProduction,
                 systemvars: isProduction,
             }),
+            new webpack.DefinePlugin({
+                "process.env.APP_VERSION": JSON.stringify(appVersion),
+                "process.env.DATA_VERSION": JSON.stringify(dataVersion),
+            }),
             new CleanWebpackPlugin({
                 verbose: true,
             }),
@@ -94,6 +111,15 @@ module.exports = (env, argv) => {
             new HtmlWebpackPlugin({
                 template: "assets/index.html",
                 favicon: "assets/favicon.ico",
+            }),
+            new CopyWebpackPlugin({
+                patterns: [
+                    {
+                        from: path.join(sourcePath, "assets/election-data"),
+                        to: path.join(outPath, "assets/election-data"),
+                        noErrorOnMissing: true,
+                    },
+                ],
             }),
         ],
         devServer: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -117,7 +117,7 @@ module.exports = (env, argv) => {
                     {
                         from: path.join(sourcePath, "assets/election-data"),
                         to: path.join(outPath, "assets/election-data"),
-                        noErrorOnMissing: true,
+                        noErrorOnMissing: false,
                     },
                 ],
             }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1440,7 +1440,7 @@ cookie@~0.7.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
-copy-webpack-plugin@^14.0.0:
+copy-webpack-plugin@14.0.0:
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-14.0.0.tgz#cd253b60e8e55bb41019dfe3ef2979ba705592c7"
   integrity sha512-3JLW90aBGeaTLpM7mYQKpnVdgsUZRExY55giiZgLuX/xTQRUs1dOCwbBnWnvY6Q6rfZoXMNwzOQJCSZPppfqXA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1440,6 +1440,17 @@ cookie@~0.7.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
+copy-webpack-plugin@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-14.0.0.tgz#cd253b60e8e55bb41019dfe3ef2979ba705592c7"
+  integrity sha512-3JLW90aBGeaTLpM7mYQKpnVdgsUZRExY55giiZgLuX/xTQRUs1dOCwbBnWnvY6Q6rfZoXMNwzOQJCSZPppfqXA==
+  dependencies:
+    glob-parent "^6.0.1"
+    normalize-path "^3.0.0"
+    schema-utils "^4.2.0"
+    serialize-javascript "^7.0.3"
+    tinyglobby "^0.2.12"
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -2059,6 +2070,11 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
+fdir@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
+
 figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -2244,6 +2260,13 @@ getpass@^0.1.1:
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
   dependencies:
     assert-plus "^1.0.0"
+
+glob-parent@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
+  dependencies:
+    is-glob "^4.0.3"
 
 glob-parent@~5.1.2:
   version "5.1.2"
@@ -3419,7 +3442,7 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
   integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
-picomatch@^4.0.0, picomatch@^4.0.3:
+picomatch@^4.0.0, picomatch@^4.0.3, picomatch@^4.0.4:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.5.tgz#51ea57a17d86f605f81039595fbc40ed06a55fab"
   integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
@@ -3932,7 +3955,7 @@ schema-utils@^2.6.1, schema-utils@^2.6.5, schema-utils@^2.6.6:
     ajv "^6.12.0"
     ajv-keywords "^3.4.1"
 
-schema-utils@^4.0.0, schema-utils@^4.3.0, schema-utils@^4.3.3:
+schema-utils@^4.0.0, schema-utils@^4.2.0, schema-utils@^4.3.0, schema-utils@^4.3.3:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.3.3.tgz#5b1850912fa31df90716963d45d9121fdfc09f46"
   integrity sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==
@@ -3992,6 +4015,11 @@ send@~0.19.0, send@~0.19.1:
     on-finished "~2.4.1"
     range-parser "~1.2.1"
     statuses "~2.0.2"
+
+serialize-javascript@^7.0.3:
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.7.tgz#06ec40576d4cea96d68010a534520bff1f948a72"
+  integrity sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==
 
 serve-index@^1.9.1:
   version "1.9.1"
@@ -4356,6 +4384,14 @@ through@2, through@~2.3, through@~2.3.1:
 thunky@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.0.3.tgz#f5df732453407b09191dae73e2a8cc73f381a826"
+
+tinyglobby@^0.2.12:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
+  integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.4"
 
 tmp@0.1.0:
   version "0.1.0"


### PR DESCRIPTION
- Replaces all five live API fetches (`votes`, `metrics`, `parameters`, `years`, `parties`) with static JSON file requests served from `/assets/election-data/` — no runtime API dependency for data
- Adds `dataVersion` field to `package.json` (pinned to the Lavinia-api release tag) and a `yarn download-data` script that fetches, SHA-256 verifies, and extracts the election-data bundle from the pinned GitHub release
- Injects `APP_VERSION` and `DATA_VERSION` as build-time constants via webpack `DefinePlugin`; `stateIsInvalid()` now uses these instead of a hardcoded version constant, so `localStorage` is automatically busted when either the app or its data bundle changes
- Adds `copy-webpack-plugin` to copy `src/assets/election-data/` into `dist/` so the static files are served in production builds; `src/assets/election-data` is gitignored
- Extends the CI release pipeline: before building, the `test-and-build` job downloads and SHA-256 verifies the corresponding `election-data.zip` from the pinned Lavinia-api release (using GitHub's native `digest` field — no separate `.sha256` asset needed), validates the extracted `manifest.json` version, then uploads the result as a workflow artifact. The `package` job downloads that same artifact rather than re-fetching from GitHub, so the built release always bundles exactly the data that Cypress tested against

## Developer workflow

```bash
yarn download-data   # fetch + verify the pinned election-data bundle into src/assets/election-data/
yarn start           # dev server serves static files directly from src/assets/election-data/
```

## Test plan

- [x] Run `yarn download-data` on a fresh clone — verify files land in `src/assets/election-data/` and `manifest.json` version matches `package.json#dataVersion`
- [x] Run `yarn start` — verify the application loads election data without errors
- [x] Run `yarn build` — verify `dist/assets/election-data/` is populated and the bundle references the correct `DATA_VERSION`
