### PR TITLE
fix(icons): Replace fa-kit vendored icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
         "html-webpack-plugin": "^5.6.0",
         "husky": "^4.2.5",
         "mini-css-extract-plugin": "^2.9.0",
-        "sass": "^1.83.0",
         "prettier": "^2.0.5",
         "pretty-quick": "^2.0.1",
+        "sass": "^1.83.0",
         "sass-loader": "^8.0.2",
         "start-server-and-test": "^1.11.0",
         "style-loader": "^1.2.1",
@@ -58,6 +58,7 @@
         "webpack-dev-server": "^4.15.2"
     },
     "dependencies": {
+        "@heroicons/react": "2.2.0",
         "bulma-toast": "^2.0.3",
         "lodash": "^4.17.21",
         "react": "^16.13.1",

--- a/src/Layout/Presentation/SingleDistrict/SingleDistrict.tsx
+++ b/src/Layout/Presentation/SingleDistrict/SingleDistrict.tsx
@@ -16,6 +16,7 @@ import {
     createPartyResultMap,
 } from "../../../utilities/district";
 import { isQuotientAlgorithm } from "../../../computation/logic";
+import { TrophyIcon } from "../../../common";
 
 export interface SingleDistrictProps {
     districtResults: DistrictResult[];
@@ -156,16 +157,12 @@ export class SingleDistrict extends React.Component<SingleDistrictProps, {}> {
                                     ? vulnerableMap.get(d.partyCode)
                                     : null,
                             Cell: (row) => {
-                                const value = numberFormat(row.value);  
+                                const value = numberFormat(row.value);
                                 if (vulnerableVotes && row.original.partyCode === vulnerableVotes.partyCode) {
                                     return <div className="has-background-dark has-text-white">{value}</div>;
                                 }
                                 if (vulnerableVotes && row.original.partyCode === vulnerableVotes.winner.partyCode) {
-                                    return (
-                                        <span className="icon">
-                                            <i className="fas fa-trophy" />
-                                        </span>
-                                    );
+                                    return <TrophyIcon />;
                                 }
                                 return value;
                             },

--- a/src/Layout/Presentation/SingleParty/SingleParty.tsx
+++ b/src/Layout/Presentation/SingleParty/SingleParty.tsx
@@ -18,6 +18,7 @@ import {
 import { isQuotientAlgorithm } from "../../../computation/logic";
 import { numberFormat } from "../../../utilities/customNumberFormat";
 import { InfoBox } from "./InfoBox";
+import { TrophyIcon } from "../../../common";
 
 export interface SinglePartyProps {
     districtResults: DistrictResult[];
@@ -217,16 +218,12 @@ export class SingleParty extends React.Component<SinglePartyProps, {}> {
                             Header: <span className="is-pulled-right wrap" >Margin i stemmer</span>,
                             accessor: "marginInVotes",
                             Cell: (row) => {
-                                const value = numberFormat(row.value);  
+                                const value = numberFormat(row.value);
                                 if ( row.original.closestVotes ) {
                                     return <div className="has-background-dark has-text-white">{value}</div>;
                                 }
                                 if ( row.original.seatWinner ) {
-                                    return (
-                                        <span className="icon">
-                                            <i className="fas fa-trophy" />
-                                        </span>
-                                    );
+                                    return <TrophyIcon />;
                                 }
                                 return value;
                             },

--- a/src/common/TooltipInfo/TooltipInfo.tsx
+++ b/src/common/TooltipInfo/TooltipInfo.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { checkExhaustively } from "../../utilities";
 import { toast } from "bulma-toast";
+import { InformationCircleIcon } from "@heroicons/react/24/solid";
 
 export enum TooltipDirection {
     TOP = "TOP",
@@ -44,9 +45,13 @@ export class TooltipInfo extends React.Component<TooltipInfoProps, {}> {
     render() {
         const finalDirection = this.props.direction || TooltipDirection.TOP;
         return (
-            <span className={getClassName(finalDirection)} data-tooltip={this.props.text}>
+            <span
+                className={getClassName(finalDirection)}
+                data-tooltip={this.props.text}
+                style={{ verticalAlign: "middle" }}
+            >
                 <a href={this.props.url} target="_blank" rel="noreferrer noopener">
-                <i className="fas fa-info-circle has-text-primary" />
+                    <InformationCircleIcon className="icon has-text-primary" />
                 </a>
             </span>
         );

--- a/src/common/TrophyIcon/TrophyIcon.tsx
+++ b/src/common/TrophyIcon/TrophyIcon.tsx
@@ -1,0 +1,8 @@
+import * as React from "react";
+import { TrophyIcon as HeroTrophyIcon } from "@heroicons/react/24/solid";
+
+export class TrophyIcon extends React.Component<{}, {}> {
+    render() {
+        return <HeroTrophyIcon className="icon" style={{ verticalAlign: "middle" }} />;
+    }
+}

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -3,3 +3,4 @@ export * from "./SmartNumericInput";
 export * from "./SmartNumericInputWithLabel";
 export * from "./TooltipInfo";
 export * from "./LaviniaSVGLogo";
+export * from "./TrophyIcon/TrophyIcon";

--- a/yarn.lock
+++ b/yarn.lock
@@ -100,6 +100,11 @@
   dependencies:
     "@hapi/hoek" "^8.3.0"
 
+"@heroicons/react@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@heroicons/react/-/react-2.2.0.tgz#0c05124af50434a800773abec8d3af6a297d904b"
+  integrity sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==
+
 "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"


### PR DESCRIPTION
# Description
Replaces the Font Awesome Kit icons we used, where we got a 403 and no one remembers who set this up this way or why.

# Testing
Check single district and single party views for the trophy rendering decently.
Check that information icons render decently.

## Setup
Needs a yarn install because we added a package.

## Expected
The trophy should render in such a way it's clearly a trophy.
The icons should render and be visually similar to how they were before (identical not a requirement for this changeset).

## Issues closed
Closes #325 
