### PR TITLE
chore(build): Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+


### PR DESCRIPTION
# Description

Adds a Dependabot config. Apparently we were so early using this that we don't even match the default setup (yet it kept running).

## Issues closed
Closes #333 