### PR TITLE
fix: correct tie-breaking logic in breakTies function

### DIFF
--- a/src/computation/logic/utils.ts
+++ b/src/computation/logic/utils.ts
@@ -318,9 +318,9 @@ export function breakTies(winners: KeyValuePair[], baseValue: _.Dictionary<numbe
     const maxNumerator = Math.max(...numerators);
 
     // Filter out all winners that did not have the highest numerator
-    winnersCopy.filter((item) => baseValue[item.key] === maxNumerator);
+    const narrowed = winnersCopy.filter((item) => baseValue[item.key] === maxNumerator);
 
     // We will always do the coin flip, because if there is only 1 item there is 100% chance of it being selected.
     // And the coinflip should be performed if there are more than 1 item remaining at this stage
-    return winnersCopy[Math.floor(Math.random() * winnersCopy.length)];
+    return narrowed[Math.floor(Math.random() * narrowed.length)];
 }


### PR DESCRIPTION
This pull request fixes a bug in the `breakTies` function in `src/computation/logic/utils.ts` to ensure that the random selection is only performed among the actual top-scoring winners, not the full original list.

Bug fix:
* Corrected the random selection logic in `breakTies` so that it only selects from the filtered list of winners with the highest numerator, rather than from the unfiltered list.

## How to test
We do not actually have any election results that would be impacted by this change, as it's such a rare edge case that none of our voting data meets the requirements regardless of the settings chosen.

## Issues closed
Closes #329 
