### PR TITLE
Implement CI/CD workflows for Cloudflare Pages deployment

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,79 @@
+# CI/CD pipeline
+
+The client is a static SPA. Every build bundles the election data (fetched by
+`yarn download-data`) into `dist/`, and deployment is a plain upload of `dist/`
+to [Cloudflare Pages](https://developers.cloudflare.com/pages/) via Wrangler.
+
+## Workflows
+
+| Workflow | Trigger | What it does |
+| --- | --- | --- |
+| **`build.yml`** | `workflow_call` (reusable) | Downloads election data, builds `dist`, and optionally runs the Cypress E2E suite. The single source of truth for how the client is built. Uploads the `dist` artifact. |
+| **`pr-validation.yml`** | Pull request → `master`/`development` | Calls `build.yml` (build only, no Cypress) to confirm a PR compiles. |
+| **`staging.yml`** | Push to `master` | Calls `build.yml` (with Cypress), then deploys `dist` as a **preview** on the `lavinia` project (`--branch=staging`), reachable at `staging.lavinia.pages.dev`. |
+| **`release.yml`** | Push tag `x.y.z` | Verifies the tag matches `package.json` version → `build.yml` → zips `dist` into `artifact.zip` and publishes a GitHub Release → calls `deploy.yml`. |
+| **`deploy.yml`** | `workflow_call` + `workflow_dispatch` | Downloads a release's `artifact.zip` and deploys it to **production** on the `lavinia` project (`--branch=master`). |
+
+Staging and production share a single `lavinia` Pages project: staging is a
+preview deployment (`--branch=staging`), production is the production branch
+(`--branch=master`). The `lavinia.no` custom domain only ever serves production.
+
+```
+PR ──────────────► build.yml (no Cypress)
+
+push master ─────► build.yml (Cypress) ──► lavinia preview (staging.lavinia.pages.dev)
+
+push tag x.y.z ──► guard ──► build.yml (Cypress) ──► package (Release) ──► deploy.yml ──► lavinia production
+                                                                              ▲
+manual dispatch ──────────────────────────────────────────────────────────────┘
+```
+
+Production always ships the immutable `artifact.zip` attached to the GitHub
+Release, so a deploy is byte-identical to what was built and tested for that tag.
+
+## Re-deploying (or rolling back to) an older tag
+
+`deploy.yml` can be run manually to redeploy any tag that already has a published
+GitHub Release — useful for rolling back production to a previous version:
+
+1. GitHub → **Actions** → **Deploy** → **Run workflow**.
+2. Leave **"Use workflow from"** on `master` — that dropdown only picks which
+   version of `deploy.yml` runs, not what gets deployed.
+3. Type the release tag (e.g. `2.9.8`) into the **tag** field. It's a free-text
+   box (GitHub can't offer a dynamic tag picker); the workflow validates that
+   the value is an existing **published** release and fails fast otherwise, so a
+   branch name, typo, or draft tag is rejected before anything deploys.
+4. Run it. The workflow pulls that release's `artifact.zip` and deploys it to
+   the `lavinia` production project. No rebuild happens — the exact bytes that
+   originally shipped are redeployed.
+
+## One-time setup
+
+A single **Direct Upload** Cloudflare Pages project with `master` as the
+production branch (staging is served from a preview branch on the same project):
+
+```bash
+npx wrangler pages project create lavinia --production-branch=master
+```
+
+Repository secrets (Settings → Secrets and variables → Actions):
+
+| Secret | Used by | Notes |
+| --- | --- | --- |
+| `CLOUDFLARE_API_TOKEN` | staging/deploy | Scope: **Account · Cloudflare Pages · Edit**, restricted to your account. |
+| `CLOUDFLARE_ACCOUNT_ID` | staging/deploy | From `wrangler whoami` or the dashboard URL. |
+| `CYPRESS_RECORD_KEY` | build (Cypress) | Enables parallel recording in Cypress Cloud. Optional. |
+
+`GITHUB_TOKEN` is provided automatically; no PAT is required — the release →
+deploy handoff uses `workflow_call`, which is not subject to the rule that
+`GITHUB_TOKEN`-published events don't trigger further workflows.
+
+## Knobs
+
+- **Cypress on staging / PRs** — the `run_cypress` input to `build.yml`
+  (`staging.yml` passes `true`, `pr-validation.yml` passes `false`).
+- **Pages project / branch** — the `--project-name` (both `lavinia`) and
+  `--branch` flags: `staging.yml` uses `--branch=staging` (preview), `deploy.yml`
+  uses `--branch=master` (production).
+- **`WIKI`** and Node version — the top-level `env` block in `build.yml`. This
+  is the only place the client's build environment is defined.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: '20'
   # Injected into the production bundle at build time (webpack systemvars).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,109 @@
+name: Build & Test
+
+# Reusable build pipeline shared by the release and staging workflows.
+# Produces a deployable `dist` artifact (election data is bundled into it by
+# the CopyWebpackPlugin step) and, optionally, runs the Cypress E2E suite.
+
+on:
+  workflow_call:
+    inputs:
+      run_cypress:
+        description: 'Run the Cypress E2E suite'
+        type: boolean
+        default: true
+
+env:
+  NODE_VERSION: '20'
+  # Injected into the production bundle at build time (webpack systemvars).
+  # Keep in sync with any other workflow that builds the client.
+  WIKI: https://wiki.lavinia.no/
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'yarn'
+
+      - name: Download static election data bundle
+        run: yarn download-data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload election data artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: election-data
+          path: src/assets/election-data/
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  test:
+    name: Cypress
+    if: ${{ inputs.run_cypress }}
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+      BUILD_BUILDNUMBER: ${{ github.run_id }}-${{ github.run_attempt }}
+    strategy:
+      matrix:
+        container: [1, 2, 3]
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'yarn'
+
+      - name: Download election data artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: election-data
+          path: src/assets/election-data/
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Cypress verify
+        run: yarn cy:verify
+
+      - name: Run Cypress tests (parallel)
+        run: |
+          if [ -n "$CYPRESS_RECORD_KEY" ]; then
+            CYPRESS_PARALLEL_ARGS="--record --key $CYPRESS_RECORD_KEY --parallel --ci-build-id $BUILD_BUILDNUMBER";
+          else
+            CYPRESS_PARALLEL_ARGS="";
+          fi
+          npx start-server-and-test start:production 3000 "cypress run --reporter junit --reporter-options mochaFile=results/cypress-[hash].xml,toConsole=true $CYPRESS_PARALLEL_ARGS"
+
+      - name: Upload junit results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-junit-${{ matrix.container }}
+          path: results
+          if-no-files-found: ignore

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,63 @@
+name: Deploy
+
+# Production deploy pipeline. Deploys the immutable `artifact.zip` attached to a
+# GitHub Release to the production Cloudflare Pages project.
+#
+#   - Called by `release.yml` (workflow_call) right after a release is published.
+#   - Can be run manually (workflow_dispatch) to re-deploy any older tag — it
+#     redeploys the exact bytes that originally shipped, no rebuild.
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag to deploy'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to (re)deploy, e.g. 2.9.9'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to production
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify tag is a published release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          if ! gh release view "$TAG" --repo "$REPO" --json isDraft > release.json 2>/dev/null; then
+            echo "::error::No GitHub Release found for '$TAG'. Enter an existing release tag — a branch name or arbitrary ref is not valid."
+            exit 1
+          fi
+          if [ "$(jq -r '.isDraft' release.json)" = "true" ]; then
+            echo "::error::Release '$TAG' is a draft; only published releases can be deployed."
+            exit 1
+          fi
+          echo "Deploying release '$TAG'."
+
+      - name: Download release artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh release download "$TAG" --repo "$REPO" --pattern artifact.zip --dir .
+          mkdir -p dist
+          unzip -o artifact.zip -d dist
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=lavinia --branch=master

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -9,6 +9,9 @@ concurrency:
   group: pr-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Reuse the shared build pipeline so PRs are built exactly like staging and
   # release (same WIKI/env, same steps). Cypress is skipped to keep PRs fast —

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -9,41 +9,14 @@ concurrency:
   group: pr-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  NODE_VERSION: '20'
-
 jobs:
-  build-artifact:
-    name: Build Production Bundle
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'yarn'
-
-      - name: Download static election data bundle
-        run: yarn download-data
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install dependencies
-        run: yarn --frozen-lockfile
-
-      - name: Build
-        run: yarn build
-
-      - name: Zip dist
-        run: |
-          cd dist
-          zip -r ../artifact.zip .
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifact-dist
-          path: artifact.zip
+  # Reuse the shared build pipeline so PRs are built exactly like staging and
+  # release (same WIKI/env, same steps). Cypress is skipped to keep PRs fast —
+  # the full E2E suite runs post-merge in staging.yml. Set run_cypress to true
+  # to gate PRs on the E2E suite as well.
+  build:
+    name: Build & Test
+    uses: ./.github/workflows/build.yml
+    with:
+      run_cypress: false
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,33 +12,15 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
-env:
-  NODE_VERSION: '20'
-
 jobs:
-  test-and-build:
-    name: Test & Build
+  guard:
+    name: Verify version
     runs-on: ubuntu-latest
-    timeout-minutes: 60
-    env:
-      CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-      BUILD_BUILDNUMBER: ${{ github.run_id }}-${{ github.run_attempt }}
-      WIKI: https://wiki.lavinia.no/
-    strategy:
-      matrix:
-        container: [1, 2, 3]
-      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'yarn'
-
-      - name: Resolve app/data versions from package.json
+      - name: Verify tag matches package.json version
         run: |
           APP_VERSION=$(node -p "require('./package.json').version")
           API_DATA_VERSION=$(node -p "require('./package.json').dataVersion")
@@ -61,106 +43,29 @@ jobs:
           echo "Using package.json app version: $APP_VERSION"
           echo "Using package.json data version: $API_DATA_VERSION"
 
-      - name: Download static election data bundle
-        run: yarn download-data
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload election data artifact
-        if: matrix.container == 1
-        uses: actions/upload-artifact@v4
-        with:
-          name: election-data
-          path: src/assets/election-data/
-
-      - name: Install dependencies
-        run: yarn --frozen-lockfile
-
-      - name: Build
-        run: yarn build
-
-      - name: Cypress verify
-        run: yarn cy:verify
-
-      - name: Run Cypress tests (parallel)
-        run: |
-          if [ -n "$CYPRESS_RECORD_KEY" ]; then
-            CYPRESS_PARALLEL_ARGS="--record --key $CYPRESS_RECORD_KEY --parallel --ci-build-id $BUILD_BUILDNUMBER";
-          else
-            CYPRESS_PARALLEL_ARGS="";
-          fi
-          npx start-server-and-test start:production 3000 "cypress run --reporter junit --reporter-options mochaFile=results/cypress-[hash].xml,toConsole=true $CYPRESS_PARALLEL_ARGS"
-
-      - name: Upload junit results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: cypress-junit-${{ matrix.container }}
-          path: results
-          if-no-files-found: ignore
+  build:
+    name: Build & Test
+    needs: guard
+    uses: ./.github/workflows/build.yml
+    with:
+      run_cypress: true
+    secrets: inherit
 
   package:
     name: Package & Release
+    needs: build
     runs-on: ubuntu-latest
-    needs: test-and-build
-    if: needs.test-and-build.result == 'success'
-    env:
-      WIKI: https://wiki.lavinia.no/
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'yarn'
-
-      - name: Resolve app/data versions from package.json
-        run: |
-          APP_VERSION=$(node -p "require('./package.json').version")
-          API_DATA_VERSION=$(node -p "require('./package.json').dataVersion")
-
-          if [ -z "$APP_VERSION" ]; then
-            echo "Missing package.json field: version."
-            exit 1
-          fi
-
-          if [ -z "$API_DATA_VERSION" ]; then
-            echo "Missing package.json field: dataVersion."
-            exit 1
-          fi
-
-          if [ "$APP_VERSION" != "$GITHUB_REF_NAME" ]; then
-            echo "Tag/version mismatch: package.json version '$APP_VERSION' does not match release tag '$GITHUB_REF_NAME'."
-            exit 1
-          fi
-
-          echo "Using package.json app version: $APP_VERSION"
-          echo "Using package.json data version: $API_DATA_VERSION"
-
-      - name: Download election data artifact
+      - name: Download dist artifact
         uses: actions/download-artifact@v4
         with:
-          name: election-data
-          path: src/assets/election-data/
-
-      - name: Install dependencies
-        run: yarn --frozen-lockfile
-
-      - name: Build
-        run: yarn build
+          name: dist
+          path: dist/
 
       - name: Zip dist
         run: |
           cd dist
           zip -r ../artifact.zip .
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifact-dist
-          path: artifact.zip
 
       - name: Create GitHub Release
         id: create_release
@@ -170,3 +75,11 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy:
+    name: Deploy to production
+    needs: package
+    uses: ./.github/workflows/deploy.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,41 @@
+name: Staging
+
+# Deploys every merge to master as a preview deployment on the production
+# Cloudflare Pages project, reachable at staging.lavinia.pages.dev.
+# Reuses the same build/test logic as the release pipeline (build.yml).
+
+on:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: staging
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build & Test
+    uses: ./.github/workflows/build.yml
+    with:
+      run_cypress: true
+    secrets: inherit
+
+  deploy:
+    name: Deploy to staging
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Deploy to Cloudflare Pages (staging preview)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # --branch != the project's production branch (master) => preview deploy
+          command: pages deploy dist --project-name=lavinia --branch=staging

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -13,6 +13,9 @@ concurrency:
   group: staging
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build & Test

--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ Read more about Lavinia and the Norwegian election system in our [wiki](https://
 5. Type `yarn start` <kbd>Enter</kbd>
 
 After step 5. your default browser should have opened up, running a development server locally on your machine. In most terminals, hit <kbd>Ctrl</kbd>+<kbd>c</kbd> with your terminal focused to close the application.
+
+## Deployment & CI
+
+The app is hosted on [Cloudflare Pages](https://developers.cloudflare.com/pages/): merges to `master` deploy to staging, and tagged releases deploy to production. See [`.github/workflows/README.md`](.github/workflows/README.md) for the full pipeline, one-time setup, and how to re-deploy or roll back to an older release.


### PR DESCRIPTION
This pull request refactors the CI/CD pipeline to use modular, reusable GitHub Actions workflows for building, testing, and deploying the application. The main improvements are the introduction of shared workflow files, streamlined deployment logic, and enhanced documentation.

**CI/CD Pipeline Modularization and Reuse**
- Introduced a shared `build.yml` workflow for building the app and running Cypress tests, now reused by PR validation, staging, and release workflows for consistency. (`.github/workflows/build.yml`, [.github/workflows/build.ymlR1-R109](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R1-R109))
- Added a shared `deploy.yml` workflow for production deployments, supporting both automatic and manual (re-)deployments of release artifacts. (`.github/workflows/deploy.yml`, [.github/workflows/deploy.ymlR1-R63](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R1-R63))
- Updated `pr-validation.yml` and `release.yml` to delegate building and testing to the shared `build.yml`, removing duplicated steps and environment definitions. (`.github/workflows/pr-validation.yml`, [[1]](diffhunk://#diff-04af3c9c96028eebf4fa93d5c67e1fa08255fb7a3682f912ccd5bea1dff5ccd4L12-R22); `.github/workflows/release.yml`, [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L15-R23) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L64-L164)

**Deployment Logic and Workflow Improvements**
- Added a new `staging.yml` workflow to deploy every merge to `master` as a preview to Cloudflare Pages, using the shared build logic. (`.github/workflows/staging.yml`, [.github/workflows/staging.ymlR1-R41](diffhunk://#diff-7bb7a67ed05f3845ed1f1b92dc4b87dfb0dd9aba208cca5489055ccef315117bR1-R41))
- Refactored the release workflow to separate version verification (`guard` job), building/testing, packaging, and deployment into distinct jobs, improving clarity and reliability. (`.github/workflows/release.yml`, [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L15-R23) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L64-L164) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R78-R85)
- Ensured production deployments always use the exact `artifact.zip` attached to the GitHub Release, making rollbacks and redeployments deterministic and safe. (`.github/workflows/deploy.yml`, [.github/workflows/deploy.ymlR1-R63](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R1-R63))

**Documentation Enhancements**
- Added a comprehensive `.github/workflows/README.md` detailing the new pipeline structure, triggers, one-time setup, and redeployment instructions. (`.github/workflows/README.md`, [.github/workflows/README.mdR1-R79](diffhunk://#diff-636942e0afa55e1aea027fb857aa2c6046858fb317c0b9a4f12ff3ca17e64ffbR1-R79))
- Updated the main `README.md` with a summary of deployment and CI, referencing the new documentation. (`README.md`, [README.mdR35-R38](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R35-R38))