### PR TITLE
fix: Disable webpack warning overlay

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 180
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -138,6 +138,12 @@ module.exports = (env, argv) => {
             historyApiFallback: {
                 disableDotRule: true,
             },
+            client: {
+                overlay: {
+                    errors: true,
+                    warnings: false,
+                },
+            },
         },
     };
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -140,8 +140,8 @@ module.exports = (env, argv) => {
             },
             client: {
                 overlay: {
-                    errors: true,
-                    warnings: false,
+                    errors: !isProduction,
+                    warnings: !isProduction,
                 },
             },
         },


### PR DESCRIPTION
# Description
This PR disables the webpack overlay for warnings to avoid it breaking the Cypress tests. The overlay should still appear on errors.

The PR also extends the deadline for the Cypress test suite to 3 hours, as it can take well over an hour when running sequentially.