### PR TITLE
chore: Remove forgotten FA kit link

### DIFF
--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -5,7 +5,6 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <link rel="stylesheet" href="https://unpkg.com/react-table@6.10.0/react-table.css" />
         <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" />
-        <script src="https://kit.fontawesome.com/05579d3562.js" crossorigin="anonymous"></script>
         <title>Lavinia</title>
     </head>
     <body>


### PR DESCRIPTION
# Description
Removes a forgotten link that always 403s. 

# Testing
N/A

## Setup
N/A

## Expected

Everything still works the same (particularly the now-replaced icons).

## Issues closed
Closes #344
