### PR TITLE
fix: Use 1 as first divisor post 2005 reform

### DIFF
--- a/src/computation/logic/algorithm-utilities.ts
+++ b/src/computation/logic/algorithm-utilities.ts
@@ -435,7 +435,7 @@ export function calculateFinalQuotients(
 }
 
 /**
- * Sorts a list of leveling seats as described here: https://lovdata.no/NL/lov/2002-06-28-57/§11-6
+ * Sorts a list of leveling seats as described in §11-8: https://lovdata.no/lov/2023-06-16-62/§11-8
  * @param levelingSeats The list of leveling seats to be sorted
  * @param partyResults A _.Dictionary used to look up how many votes the parties got
  */

--- a/src/computation/logic/distribute-levelling-seats.ts
+++ b/src/computation/logic/distribute-levelling-seats.ts
@@ -7,7 +7,9 @@ import { isLargestFractionAlgorithm, isQuotientAlgorithm } from "./algorithm-uti
 import { reform2005Applies } from "../../utilities/conditionals";
 
 /**
- * Distributes the leveling seats on the parties and on each district.
+ * Distributes the leveling seats on the parties (§11-7) and on each district (§11-8):
+ * https://lovdata.no/lov/2023-06-16-62/§11-7
+ * https://lovdata.no/lov/2023-06-16-62/§11-8
  *
  * @param payload The computation payload
  * @param partyResults The party results for each party
@@ -71,7 +73,8 @@ export function distributeLevelingSeats(
 }
 
 /**
- * Filters out parties that do not receive more seats in the national distribution than the district distribution.
+ * Filters out parties that do not receive more seats in the national distribution than the district distribution,
+ * as per §11-7: https://lovdata.no/lov/2023-06-16-62/§11-7
  * It returns the remaining party codes and the final national distribution of seats.
  *
  * @param levelingPartyCodes The party codes to filter
@@ -156,7 +159,8 @@ function finalLevelingSeatDistribution(
 }
 
 /**
- * Distributes leveling seats on each party using one of the quotient algorithms.
+ * Distributes leveling seats on each party using one of the quotient algorithms,
+ * as per §11-7: https://lovdata.no/lov/2023-06-16-62/§11-7
  *
  * @param levelingPartyCodes The party codes for the parties that may win a leveling seat
  * @param partyResults The party results for each party

--- a/src/computation/logic/lague-dhondt.ts
+++ b/src/computation/logic/lague-dhondt.ts
@@ -73,7 +73,7 @@ export function lagueDhont(payload: ComputationPayload): LagueDhontResult {
         reform2005Applies(payload.parameters.electionYear) && isQuotientAlgorithm(payload.algorithm);
     const finalQuotients = calculateFinalQuotients(
         payload.algorithm,
-        payload.firstDivisor,
+        useAdjustedQuotients ? 1 : payload.firstDivisor,
         useAdjustedQuotients,
         districtResults
     );

--- a/src/computation/logic/utils.ts
+++ b/src/computation/logic/utils.ts
@@ -108,7 +108,7 @@ export function calculatePercentages(
 
 /**
  * Distributes the district seats over the districts as per:
- * https://lovdata.no/lov/2002-06-28-57/§11-3
+ * https://lovdata.no/lov/2023-06-16-62/§11-3
  *
  * @param areaFactor The area factor the area should be multiplied with when calculating the numerator for the quotient
  * @param numDistrictSeats The number of district seats that should be distributed


### PR DESCRIPTION
# Description
The Restkvotienter view showed incorrect quotients for post-2005 elections. For parties with zero district seats in a district, the displayed quotient was based on votes ÷ 1.4 instead of votes ÷ 1, making those cells a factor 1.4 too small.

Per valgloven § 11-8, the geographic distribution of leveling seats uses quotients of votes ÷ (2n + 1), where n is the party's district seats in that district — i.e. divisor 1 for parties without seats. The 1.4 first divisor (modified Sainte-Laguë) only applies to the district seat distribution in § 11-4.

The seat distribution itself (generateLevelingSeatArray) already handled this correctly, hardcoding divisor 1 for post-2005 and 1.4 for pre-2005 elections. But the display path (calculateFinalQuotients, called from lagueDhont) passed payload.firstDivisor (1.4) unconditionally, so the rendered quotients didn't match the quotients actually used to allocate seats.

Seat allocation was never affected — only the displayed values.

# Testing
Compare the results from the updated code with the original results at lavinia.no.
## Setup
Make sure to clear localStorage, as a refresh does not recompute the displayed rest quotients.
## Expected
The local rest quotients for parties that won no seat in the district should be 1.4x higher than the original.
## Issues closed
Closes #348 