### PR TITLE
fix: Correct party name filter in ElectionOverview

### DIFF
--- a/src/Layout/Presentation/ElectionOverview/ElectionOverview.tsx
+++ b/src/Layout/Presentation/ElectionOverview/ElectionOverview.tsx
@@ -116,7 +116,7 @@ export class ElectionOverview extends React.Component<ElectionOverviewProps, {}>
                     columns={[
                         {
                             Header: <span className="is-pulled-left">Parti</span> ,
-                            accessor: "partyCode",
+                            accessor: "partyName",
                             filterMethod: caseInsensitiveFilterMethod,
                             Footer: <strong className="is-pulled-left">Utvalg</strong>,
                             Cell: (row) => {

--- a/src/utilities/rt.tsx
+++ b/src/utilities/rt.tsx
@@ -126,7 +126,7 @@ export function caseInsensitiveFilterMethod(filter: Filter, rows: any) {
     const id = filter.pivotId || filter.id;
     const value: string = filter.value;
     const lowerCaseInput = value.toLowerCase();
-    return typeof rows[id] === "undefined" ? String(rows[id]).toLowerCase().startsWith(lowerCaseInput) : true;
+    return typeof rows[id] !== "undefined" ? String(rows[id]).toLowerCase().startsWith(lowerCaseInput) : true;
 }
 
 /**


### PR DESCRIPTION
# Description
This PR resolves an issue with the party name filter in the Landsoversikt table. At the moment all values that are not undefined automatically pass the filter, which are all of the parties. Additionally, the filter used the party code instead of the party name, which is counterintuitive when the party name is displayed in the table.

# Testing
Typing values into the party name filter in the Landsoversikt table should now cause the table to only show the matching values.
## Issues closed
Closes #254
