### PR TITLE
chore: Bump client version to 2.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lavinia",
-    "version": "2.10.0",
+    "version": "2.11.0",
     "dataVersion": "3.5.0",
     "private": true,
     "description": "A seat distribution application for modern democracies",


### PR DESCRIPTION
# Description

Bumps the version to 2.11.0 before a release.
