### PR TITLE
chore(webpack): Use contenthash instead of hash everywhere

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,7 @@ module.exports = (env, argv) => {
         mode: argv.mode || "production",
         output: {
             path: outPath,
-            filename: "js/[name].[hash].bundle.js",
+            filename: "js/[name].[contenthash].bundle.js",
             publicPath: "/",
         },
         target: "web",


### PR DESCRIPTION
# Description
Gets rid of an annoying warning every time we build, and explicitly uses a content based hash for the bundle files (they allow for good long-term hashing, and that the app will only pull uncached what is actually needed).

# Testing

Just a regression test; it shouldn't really impact much. In production it might result in some more pulls of data if the hashes changed.

## Issues closed
Closes #371
